### PR TITLE
Add Modelsim generic support

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -171,6 +171,9 @@ class Edatool(object):
                     raise RuntimeError("Invalid data type {} for parameter '{}'".format(str(e),
                                                                                         name))
                 param_type_map[name.replace('-','_')] = _paramtype
+            else:
+                logging.warn("Parameter '{}' has unsupported type '{}' for requested backend".format(name, _paramtype))
+
         #Parse arguments
         for key,value in sorted(vars(parser.parse_args(args)).items()):
 

--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -62,7 +62,7 @@ class Modelsim(Edatool):
     tool_options = {'lists' : {'vlog_options' : 'String',
                                'vsim_options' : 'String'}}
 
-    argtypes = ['plusarg', 'vlogdefine', 'vlogparam']
+    argtypes = ['plusarg', 'vlogdefine', 'vlogparam', 'generic']
 
     def _write_build_rtl_tcl_file(self, tcl_main):
         tcl_build_rtl  = open(os.path.join(self.work_root, "edalize_build_rtl.tcl"), 'w')
@@ -119,6 +119,8 @@ class Modelsim(Edatool):
         vpi_make = open(os.path.join(self.work_root, "Makefile"), 'w')
         _parameters = []
         for key, value in self.vlogparam.items():
+            _parameters += ['{}={}'.format(key, self._param_value_str(value))]
+        for key, value in self.generic.items():
             _parameters += ['{}={}'.format(key, self._param_value_str(value))]
         _plusargs = []
         for key, value in self.plusarg.items():


### PR DESCRIPTION
This branch adds a warning about unsupported paramtypes to the parser construction and adds support to the modelsim backend for generics. This contributes to issue #7 - other pull requests might wish to add support to a wider variety of backends. 