### PR TITLE
Actually pass vcs_options to vcs

### DIFF
--- a/edalize/templates/vcs/Makefile.j2
+++ b/edalize/templates/vcs/Makefile.j2
@@ -1,7 +1,7 @@
 all: {{ name }}
 
 {{ name }}: {{ name }}.scr
-	vcs -full64 -t {{ toplevel }} -f {{ name }}.scr -o $@ {% for option in tool_options %} {{ option }} {% endfor %}
+	vcs -full64 -top {{ toplevel }} -f {{ name }}.scr -o $@ {% for option in tool_options %} {{ option }} {% endfor %}
 
 run: {{ name }}
 	./{{ name }} -l vcs.log {% for plusarg in plusargs %} {{ plusarg }} {% endfor %}

--- a/edalize/vcs.py
+++ b/edalize/vcs.py
@@ -42,7 +42,7 @@ class Vcs(Edatool):
 
         template_vars = {
             'name'              : self.name,
-            'tool_options'      : self.tool_options,
+            'tool_options'      : self.tool_options.get('vcs_options', []),
             'toplevel'          : self.toplevel,
             'plusargs'          : plusargs
         }


### PR DESCRIPTION
Turns out I wasn't passing the right thing to VCS. If you added vcs_options, the vcs compile string would just include the string "vcs_options" instead of what you actually wanted to pass.