### PR TITLE
Correct ModelSim VHDL generic handling

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -76,7 +76,8 @@ class Edatool(object):
             trim_blocks = True,
             lstrip_blocks = True,
         )
-        self.jinja_env.filters['param_value_str'] = jinja_filter_param_value_str
+        self.jinja_env.filters['param_value_str']   = jinja_filter_param_value_str
+        self.jinja_env.filters['generic_value_str'] = jinja_filter_param_value_str
 
     @classmethod
     def get_doc(cls, api_ver):

--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -9,22 +9,23 @@ from jinja2 import Environment, PackageLoader
 logger = logging.getLogger(__name__)
 
 # Jinja2 tests and filters, available in all templates
-def jinja_filter_param_value_str(value, str_quote_style=""):
+def jinja_filter_param_value_str(value, str_quote_style="", bool_is_str=False):
     """ Convert a parameter value to string suitable to be passed to an EDA tool
 
     Rules:
-    - Booleans are represented as 0/1
+    - Booleans are represented as 0/1 or "true"/"false" depending on the
+      bool_is_str argument
     - Strings are either passed through or enclosed in the characters specified
       in str_quote_style (e.g. '"' or '\\"')
     - Everything else (including int, float, etc.) are converted using the str()
       function.
     """
-    if type(value) == bool:
+    if (type(value) == bool) and not bool_is_str:
         if (value) == True:
             return '1'
         else:
             return '0'
-    elif type(value) == str:
+    elif type(value) == str or ((type(value) == bool) and bool_is_str):
         return str_quote_style + str(value) + str_quote_style
     else:
         return str(value)
@@ -261,8 +262,8 @@ class Edatool(object):
                                       logical_name))
         return (src_files, incdirs)
 
-    def _param_value_str(self, param_value, str_quote_style=""):
-        return jinja_filter_param_value_str(param_value, str_quote_style)
+    def _param_value_str(self, param_value, str_quote_style="", bool_is_str=False):
+        return jinja_filter_param_value_str(param_value, str_quote_style, bool_is_str)
 
     def _run_scripts(self, scripts):
         for script in scripts:

--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -143,7 +143,7 @@ class Modelsim(Edatool):
         for key, value in self.vlogparam.items():
             _parameters += ['{}={}'.format(key, self._param_value_str(value))]
         for key, value in self.generic.items():
-            _parameters += ['{}={}'.format(key, self._param_value_str(value))]
+            _parameters += ['{}={}'.format(key, self._param_value_str(value, bool_is_str=True))]
         _plusargs = []
         for key, value in self.plusarg.items():
             _plusargs += ['{}={}'.format(key, self._param_value_str(value))]

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -50,23 +50,33 @@ class Quartus(Edatool):
         super(Quartus, self).__init__(edam, work_root)
 
         # Acquire quartus_sh identification information from available tool if
-        # possible. We always default to Standard if a problem is encountered
-        selected = "Standard"
+        # possible. We always default to version 18.1 Standard if a problem is encountered
+        version = {
+            'major':   '18',
+            'minor':   '1',
+            'patch':   '0',
+            'date':    '01/01/2019',
+            'edition': 'Standard'
+        }
         try:
             qsh_text = subprocess.Popen(["quartus_sh", "--version"], stdout=subprocess.PIPE, env=os.environ).communicate()[0]
 
             # Attempt to pattern match the output. Examples include
             # Version 16.1.2 Build 203 01/18/2017 SJ Standard Edition
             # Version 17.1.2 Build 304 01/31/2018 SJ Pro Edition
-            match = re.search("Version \d+\.\d+\.\d+ Build \d+ \d{2}/\d{2}/\d{4} SJ (Standard|Pro) Edition", str(qsh_text))
+            version_exp = r'Version (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) ' + \
+                          r'Build (?P<build>\d+) (?P<date>\d{2}/\d{2}/\d{4}) SJ '    + \
+                          r'(?P<edition>(Lite|Standard|Pro)) Edition'
+
+            match = re.search(version_exp, str(qsh_text))
             if match != None:
-                selected = match.group(1)
+                version = match.groupdict()
         except:
             # It is possible for this to have been run on a box without
             # Quartus being installed. Allow these errors to be ignored
             logger.warning("Unable to recognise Quartus version via quartus_sh")
 
-        self.isPro = (selected == "Pro")
+        self.isPro = (version['edition'] == "Pro")
 
     """ Configuration is the first phase of the build
 

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -78,6 +78,11 @@ class Quartus(Edatool):
 
         self.isPro = (version['edition'] == "Pro")
 
+        # Before Quartus 17 VHDL boolean generics need to be strings
+        if int(version['major']) < 17:
+            self.jinja_env.filters['generic_value_str'] = \
+                partial(self.jinja_env.filters['generic_value_str'], bool_is_str=True)
+
     """ Configuration is the first phase of the build
 
     This writes the project TCL files and Makefile. It first collects all

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -78,8 +78,9 @@ class Quartus(Edatool):
 
         self.isPro = (version['edition'] == "Pro")
 
-        # Before Quartus 17 VHDL boolean generics need to be strings
-        if int(version['major']) < 17:
+        # Quartus Pro 17 and later use 1/0 for boolean generics. Other editions
+        # and versions use "true"/"false" strings
+        if (version['edition'] != "Pro") or (int(version['major']) < 17):
             self.jinja_env.filters['generic_value_str'] = \
                 partial(self.jinja_env.filters['generic_value_str'], bool_is_str=True)
 

--- a/edalize/templates/quartus/quartus-project.tcl.j2
+++ b/edalize/templates/quartus/quartus-project.tcl.j2
@@ -14,7 +14,7 @@ set_parameter -name {{k}} {{v|param_value_str}}
 {% endif %}
 {% if generic %}
 {% for k, v in generic.items() %}
-set_parameter -name {{k}} {{v|param_value_str}}
+set_parameter -name {{k}} {{v|generic_value_str}}
 {% endfor %}
 {% endif %}
 {% if vlogdefine %}


### PR DESCRIPTION
Currently attempts to set the value of a generic for ModelSim give me the following:
```
# vsim -do "run -all" -c boolean_generic -gbits=11 -gaddtwo=1
...
# ** Warning: (vsim-3351) Invalid value "1" for generic "addtwo".  Not using this value.
```
It seems ModelSim wants the strings `true` and `false` for VHDL generics. After the changes in this PR I get the following with no warning:
```
# vsim -do "run -all" -c boolean_generic -gbits=11 -gaddtwo=True
```

I believe Quartus 16 and older have the same behaviour, so a similar solution is likely required there.