### PR TITLE
verilator: fix issue with parsing cli_parser

### DIFF
--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -49,7 +49,7 @@ class Verilator(Edatool):
                         {'name' : 'mode',
                          'type' : 'String',
                          'desc' : 'Select compilation mode. Legal values are *cc* for C++ testbenches, *sc* for systemC testbenches or *lint-only* to only perform linting on the Verilog code'},
-                        {'name' : 'cli-parser',
+                        {'name' : 'cli_parser',
                          'type' : 'String',
                          'desc' : 'Select whether FuseSoC should handle command-line arguments (*mamanged*) or if they should be passed directly to the verilated model (*raw*). Default is *managed*'}],
                     'lists' : [


### PR DESCRIPTION
This fixes an error I was seeing:

```
  $ fusesoc run --target marocchino_tb --tool=icarus mor1kx-generic --elf-load /home/shorne/work/openrisc/or1k-tests/native/build/or1k/or1k-alignillegalinsn --pipeline=MAROCCHINO
  WARNING: Parse error. Ignoring file /home/shorne/work/openrisc/local-cores/mor1kx-generic/mor1kx-generic.core: Unknown item 'cli_parser in section Verilator'
  ERROR: 'mor1kx-generic' or any of its dependencies requires 'mor1kx-generic', but this core was not found
```

This seems to have been introduced by:

```
commit 022a596fdb1bd7383bd1e3eca992795e848c6095
Author: Olof Kindgren <olof.kindgren@gmail.com>
Date:   Fri Feb 22 22:59:33 2019 +0100

    Document tool options for all other backends
```