### PR TITLE
Fix Quartus Edatool

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -46,7 +46,10 @@ class Quartus(Edatool):
     This calls the parent constructor, but also identifies whether
     the current system is using a Standard or Pro edition of Quartus.
     """
-    def __init__(self, edam, work_root=None):
+    def __init__(self, edam=None, work_root=None, eda_api=None):
+        if not edam:
+            edam = eda_api
+
         super(Quartus, self).__init__(edam, work_root)
 
         # Acquire quartus_sh identification information from available tool if


### PR DESCRIPTION
If you take FuseSoC on commit 89b4ad5 and later and run `build` command
as following:

    fusesoc build --tool=quartus rv_sopc

You will get following error:

```
Traceback (most recent call last):
  File "/home/oxore/build-pkgs/fsoc/bin/fusesoc", line 11, in <module>
    load_entry_point('fusesoc', 'console_scripts', 'fusesoc')()
  File "/home/oxore/build-pkgs/fusesoc/fusesoc/main.py", line 592, in main
    args.func(cm, args)
  File "/home/oxore/build-pkgs/fusesoc/fusesoc/main.py", line 68, in build
    flags, args.system, args.backendargs, None)
  File "/home/oxore/build-pkgs/fusesoc/fusesoc/main.py", line 315, in run_backend
    work_root=work_root)
TypeError: __init__() got an unexpected keyword argument 'eda_api'
```

This commit fixes the error above by simply adding `eda_api` argument to
`Quartus` class `__init__` function and assigning it to `edam` variable as
in inherited `Edatool` class `__init__` function.