### PR TITLE
Fix Qsys filename in quartus-std-makefile template

### DIFF
--- a/edalize/templates/quartus/quartus-std-makefile.j2
+++ b/edalize/templates/quartus/quartus-std-makefile.j2
@@ -9,7 +9,7 @@ project: $(NAME).tcl
 
 qsys: project
 {% for qsys_file in src_files if qsys_file|qsys_file_filter %}
-	ip-generate --project-directory={{qsys_file.srcdir}} --output-directory={{qsys_file.dstdir}} --report-file=bsf:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.bsf --system-info=DEVICE_FAMILY="{{tool_options.family}}" --system-info=DEVICE={{tool_options.device}} --component-file={{qsys_file.srcdir}}/{{qsys_file.name}}
+	ip-generate --project-directory={{qsys_file.srcdir}} --output-directory={{qsys_file.dstdir}} --report-file=bsf:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.bsf --system-info=DEVICE_FAMILY="{{tool_options.family}}" --system-info=DEVICE={{tool_options.device}} --component-file={{qsys_file.srcdir}}/{{qsys_file.simplename}}.qsys
 	ip-generate --project-directory={{qsys_file.srcdir}} --output-directory={{qsys_file.dstdir}}/synthesis --file-set=QUARTUS_SYNTH --report-file=sopcinfo:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.sopcinfo --report-file=html:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.html --report-file=qip:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.qip --report-file=cmp:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.cmp --report-file=svd --system-info=DEVICE_FAMILY="{{tool_options.family}}" --system-info=DEVICE={{tool_options.device}} --component-file={{qsys_file.srcdir}}/{{qsys_file.simplename}}.qsys --language=VERILOG
 {% endfor %}
 


### PR DESCRIPTION
When trying to build the sockit design I encountered an error in the Makefile template. This should fix it.

Signed-off-by: Walter Goossens <waltergoossens@creative-embedded.com>