### PR TITLE
Add license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author = "Olof Kindgren",
     author_email = "olof.kindgren@gmail.com",
     description = ("Edalize is a library for interfacing EDA tools, primarily for FPGA development"),
-    license = "",
+    license = "BSD-2-Clause",
     keywords = ["VHDL", "verilog", "EDA", "hdl", "rtl", "synthesis", "FPGA", "simulation", "Xilinx", "Altera"],
     url = "https://github.com/olofk/edalize",
     long_description=read('README.rst'),


### PR DESCRIPTION
Currently setup.py doesn't populate the "license" field, which causes
`pip3 show edalize` to display this:

```
$ pip3 show edalize
Name: edalize
Version: 0.1.3
Summary: Edalize is a library for interfacing EDA tools, primarily for FPGA development
Home-page: https://github.com/olofk/edalize
Author: Olof Kindgren
Author-email: olof.kindgren@gmail.com
License: UNKNOWN
Location: /home/philipp/src/edalize
Requires: pytest, Jinja2
Required-by: fusesoc
```

After this change it looks like this:

```
$ pip3 show edalize
Name: edalize
Version: 0.1.3
Summary: Edalize is a library for interfacing EDA tools, primarily for FPGA development
Home-page: https://github.com/olofk/edalize
Author: Olof Kindgren
Author-email: olof.kindgren@gmail.com
License: BSD-2-Clause
Location: /home/philipp/src/edalize
Requires: pytest, Jinja2
Required-by: fusesoc
```