### PR TITLE
Documentation: Use ReadTheDocs theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+from datetime import datetime
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../edalize'))
@@ -20,7 +21,7 @@ sys.path.insert(0, os.path.abspath('../edalize'))
 # -- Project information -----------------------------------------------------
 
 project = 'Edalize'
-copyright = '2019, Olof Kindgren'
+copyright = '2019-{}, Olof Kindgren'.format(datetime.now().year)
 author = 'Olof Kindgren'
 
 # The short X.Y version
@@ -72,11 +73,26 @@ pygments_style = None
 
 
 # -- Options for HTML output -------------------------------------------------
-
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+# The Read the Docs theme is available from
+# https://github.com/snide/sphinx_rtd_theme
+#
+# Install with
+# - pip install sphinx_rtd_theme
+# or
+# - apt-get install python-sphinx-rtd-theme
+
+try:
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+except ImportError:
+    sys.stderr.write('Warning: The Sphinx \'sphinx_rtd_theme\' HTML theme was '+
+        'not found. Make sure you have the theme installed to produce pretty '+
+        'HTML output. Falling back to the default theme.\n')
+
+    html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -13,6 +13,7 @@ def jinja_filter_param_value_str(value, str_quote_style="", bool_is_str=False):
     """ Convert a parameter value to string suitable to be passed to an EDA tool
 
     Rules:
+
     - Booleans are represented as 0/1 or "true"/"false" depending on the
       bool_is_str argument
     - Strings are either passed through or enclosed in the characters specified


### PR DESCRIPTION
Use the ReadTheDocs theme for documentation, making it a bit less
painful to look at.