### PR TITLE
Verilator: Support configuration files

### DIFF
--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -114,8 +114,11 @@ class Verilator(Edatool):
                     f.write(src_file.name + '\n')
                 elif src_file.file_type in ['cppSource', 'systemCSource', 'cSource']:
                     opt_c_files.append(src_file.name)
-                elif src_file.file_type in ['user']:
+                elif src_file.file_type == 'vlt':
+                    f.write(src_file.name + '\n')
+                elif src_file.file_type == 'user':
                     pass
+
             f.write('--top-module {}\n'.format(self.toplevel))
             f.write('--exe\n')
             f.write('\n'.join(opt_c_files))

--- a/tests/test_verilator/cc/mor1kx-generic_0.eda.yml
+++ b/tests/test_verilator/cc/mor1kx-generic_0.eda.yml
@@ -20,6 +20,7 @@ files:
 - {file_type: systemVerilogSource, is_include_file: false, logical_name: '', name: ../../../cores/misc/sv_file.sv}
 - {file_type: UCF, is_include_file: false, logical_name: '', name: ../../../cores/misc/ucf_file.ucf}
 - {file_type: user, is_include_file: false, logical_name: '', name: ../../../cores/misc/user_file}
+- {file_type: vlt, is_include_file: false, logical_name: '', name: ../../../cores/misc/waiver.vlt}
 - {file_type: tclSource, is_include_file: false, logical_name: '', name: ../../../cores/misc/tcl_file.tcl}
 - {file_type: verilogSource, is_include_file: false, logical_name: '', name: ../../../cores/misc/vlog_file.v}
 - {file_type: vhdlSource, is_include_file: false, logical_name: '', name: ../../../cores/misc/vhdl_file.vhd}

--- a/tests/test_verilator/cc/mor1kx-generic_0.vc
+++ b/tests/test_verilator/cc/mor1kx-generic_0.vc
@@ -31,6 +31,7 @@
 ../../../cores/adv_debug_sys/Hardware/adv_dbg_if/rtl/verilog/syncreg.v
 ../../../cores/adv_debug_sys/Hardware/adv_dbg_if/rtl/verilog/adbg_wb_module.v
 ../../../cores/misc/sv_file.sv
+../../../cores/misc/waiver.vlt
 ../../../cores/misc/vlog_file.v
 ../../../cache/jtag_tap_1.13/tap/rtl/verilog/tap_top.v
 ../../../cache/mor1kx_3.1/rtl/verilog/mor1kx_branch_prediction.v

--- a/tests/test_verilator/lint-only/mor1kx-generic_0.eda.yml
+++ b/tests/test_verilator/lint-only/mor1kx-generic_0.eda.yml
@@ -4,6 +4,8 @@ files:
 - {file_type: verilogSource, is_include_file: true, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilog/include/test-defines.v}
 - {file_type: verilogSource, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/rtl/verilog/wb_intercon.v}
 - {file_type: cSource, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/tb.cpp}
+- {file_type: user, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/other_user_file.data}
+- {file_type: vlt, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/waiver.vlt}
 name: mor1kx-generic_0
 tool_options:
   fusesoc: {}

--- a/tests/test_verilator/lint-only/mor1kx-generic_0.vc
+++ b/tests/test_verilator/lint-only/mor1kx-generic_0.vc
@@ -5,6 +5,7 @@
 +incdir+../../../cores/mor1kx-generic/bench/verilog/include
 -CFLAGS -I../../../cores/mor1kx-generic/bench/verilog/include
 ../../../cores/mor1kx-generic/rtl/verilog/wb_intercon.v
+../../../cores/mor1kx-generic/bench/verilator/waiver.vlt
 --top-module orpsoc_top
 --exe
 ../../../cores/verilator_tb_utils/verilator_tb_utils.cpp

--- a/tests/test_verilator/sc/mor1kx-generic_0.eda.yml
+++ b/tests/test_verilator/sc/mor1kx-generic_0.eda.yml
@@ -4,6 +4,8 @@ files:
 - {file_type: verilogSource, is_include_file: true, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilog/include/test-defines.v}
 - {file_type: verilogSource, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/rtl/verilog/wb_intercon.v}
 - {file_type: cSource, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/tb.cpp}
+- {file_type: user, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/other_user_file.data}
+- {file_type: vlt, is_include_file: false, logical_name: '', name: ../../../cores/mor1kx-generic/bench/verilator/waiver.vlt}
 name: mor1kx-generic_0
 tool_options:
   fusesoc: {}

--- a/tests/test_verilator/sc/mor1kx-generic_0.vc
+++ b/tests/test_verilator/sc/mor1kx-generic_0.vc
@@ -5,6 +5,7 @@
 +incdir+../../../cores/mor1kx-generic/bench/verilog/include
 -CFLAGS -I../../../cores/mor1kx-generic/bench/verilog/include
 ../../../cores/mor1kx-generic/rtl/verilog/wb_intercon.v
+../../../cores/mor1kx-generic/bench/verilator/waiver.vlt
 --top-module orpsoc_top
 --exe
 ../../../cores/verilator_tb_utils/verilator_tb_utils.cpp


### PR DESCRIPTION
Verilator has support for configuration files, typically ending in
`*.vlt`. Read more about them at
https://www.veripool.org/projects/verilator/wiki/Manual-verilator#CONFIGURATION-FILES

This commit adds support to edalize to pass files with type 'waiver' as
configuration files (which is the most common use case for them), or
files with type 'user' and a file extension of '.vlt'.

Note that the current behavior of ignoring files with type 'user' is
preserved for all file extensions other than '.vlt'.