### PR TITLE
Add tclConstraint file_type for Vivado backend.

### DIFF
--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -100,6 +100,7 @@ class Vivado(Edatool):
             'xci'                 : 'read_ip',
             'xdc'                 : 'read_xdc',
             'tclSource'           : 'source',
+            'SDC'                 : 'read_xdc -unmanaged',
         }
         _file_type = f.file_type.split('-')[0]
         if _file_type in file_types:

--- a/tests/test_vivado/test_vivado_0.tcl
+++ b/tests/test_vivado/test_vivado_0.tcl
@@ -8,6 +8,7 @@ set_param project.enableVHDL2008 1
 set_property generic {vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello } [get_filesets sources_1]
 set_property generic {generic_bool=true generic_int=42 generic_str=hello } [get_filesets sources_1]
 set_property verilog_define {vlogdefine_bool=1 vlogdefine_int=42 vlogdefine_str=hello } [get_filesets sources_1]
+read_xdc -unmanaged sdc_file
 read_verilog -sv sv_file.sv
 source tcl_file.tcl
 read_verilog vlog_file.v


### PR DESCRIPTION
Vivado supports .tcl files as constraint files.
It is called unmanaged constraint file.