### PR TITLE
Remove use of undefined variable

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -217,7 +217,6 @@ class Quartus(Edatool):
     """
     def run_main(self):
         args = ['--mode=jtag']
-        args += remaining
         args += ['-o']
         args += ['p;' + self.name.replace('.', '_') + '.sof']
         self._run_tool('quartus_pgm', args)


### PR DESCRIPTION
The argument to this function was removed in commit 31eb06f, but this use of the
argument was left behind.