### PR TITLE
FileNotFoundError doesn't exist in Python 2

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -8,6 +8,9 @@ from jinja2 import Environment, PackageLoader
 
 logger = logging.getLogger(__name__)
 
+if sys.version[0] == '2':
+    FileNotFoundError = OSError
+
 # Jinja2 tests and filters, available in all templates
 def jinja_filter_param_value_str(value, str_quote_style="", bool_is_str=False):
     """ Convert a parameter value to string suitable to be passed to an EDA tool


### PR DESCRIPTION
Work around it in the same way we do in fusesoc: map FileNotFoundError
to OSError for Python 2.