### PR TITLE
Quartus: Support specification of the FPGA's device number in the JTAG chain

### DIFF
--- a/doc/edam/api.rst
+++ b/doc/edam/api.rst
@@ -182,13 +182,14 @@ vsim_options     List of String        Extra options for running the simulation 
 quartus
 ~~~~~~~
 
-================ ===================== ===========
-Field Name       Type                  Description
-================ ===================== ===========
-family           String                FPGA family e.g. *Cyclone IV E*
-device           String                Device identifier. e.g. *EP4CE55F23C8* or *5CSXFC6D6F31C8ES*
-quartus_options  List of String        Extra command-line options for Quartus
-================ ===================== ===========
+================== ===================== ===========
+Field Name         Type                  Description
+================== ===================== ===========
+board_device_index  List of String        Specifies the FPGA's device number in the JTAG chain. The device index specifies the device where the flash programmer looks for the Nios® II JTAG debug module. JTAG devices are numbered relative to the JTAG chain, starting at 1. Use the tool `jtagconfig` to determine the index.
+family              String                FPGA family e.g. *Cyclone IV E*
+device              String                Device identifier. e.g. *EP4CE55F23C8* or *5CSXFC6D6F31C8ES*
+quartus_options     List of String        Extra command-line options for Quartus
+================== ===================== ===========
 
 rivierapro
 ~~~~~~~~~~

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -29,7 +29,10 @@ class Quartus(Edatool):
                          'desc' : 'FPGA family (e.g. Cyclone V)'},
                         {'name' : 'device',
                          'type' : 'String',
-                         'desc' : 'FPGA device (e.g. 5CSXFC6D6F31C8ES)'}],
+                         'desc' : 'FPGA device (e.g. 5CSXFC6D6F31C8ES)'},
+                        {'name' : 'board_device_index',
+                         'type' : 'String',
+                         'desc' : "Specifies the FPGA's device number in the JTAG chain. The device index specifies the device where the flash programmer looks for the Nios® II JTAG debug module. JTAG devices are numbered relative to the JTAG chain, starting at 1. Use the tool `jtagconfig` to determine the index."}],
                     'lists' : [
                         {'name' : 'quartus_options',
                          'type' : 'String',
@@ -213,4 +216,8 @@ class Quartus(Edatool):
         args = ['--mode=jtag']
         args += ['-o']
         args += ['p;' + self.name.replace('.', '_') + '.sof']
+
+        if 'board_device_index' in self.tool_options:
+            args[-1] += "@" + self.tool_options['board_device_index']
+
         self._run_tool('quartus_pgm', args)


### PR DESCRIPTION
I have just done some experiments on my DE1-SoC board and ran into issues with the quartus_pgm invokation to download the image to the FPGA. In particular, there are 2 devices in the JTAG-chain on this board, and without specifying the device index explicitly in the `quartus_pgm` invokation, the download fails

    Error (209015): Can't configure device. Expected JTAG ID code 0x02D120DD for device 1, but found JTAG ID code 0x4BA00477. Make sure the location of the target device on the circuit board matches the device's location in the device chain in the Chain Description File (.cdf).
    Error (209012): Operation failed

To accomodate for the requirement to explicitly specify the device index, this PR adds a new option `board_device_index`.