### PR TITLE
Vivado: Write bitstream in project mode

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -1,4 +1,16 @@
-launch_runs impl_1
+launch_runs impl_1 -to_step write_bitstream
 wait_on_run impl_1
-open_run impl_1
-write_bitstream [current_project].bit -force
+
+puts "Bitstream generation completed"
+
+# By default, Vivado writes the bitstream to a file named after the toplevel and
+# put into the *.runs/impl_1 folder.
+# fusesoc/edalize historically used a bitstream name based on the project name,
+# and puts it into the top-level project workroot.
+# To keep backwards-compat, copy the Vivado default bitstream file to the
+# traditional edalize location.
+# The Vivado default name is beneficial when using the GUI, as it is set as
+# default bitstream in the "Program Device" dialog; non-standard names need to
+# be selected from a file picker first.
+set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
+file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit


### PR DESCRIPTION
Currently, we use Vivado in Project Mode for synthesis and
implementation steps, but not for the bitstream generation. This commit
also uses project mode for the bitstream writing, enabling the use of
hooks at that stage.

The only complication is the name of the bitstream file; fusesoc/edalize
are defaulting to a bitstream name based on the project name, while
Vivado defaults to a bitstream name based on the toplevel. There's no
(apparently) no way to change the bitstream name in project mode, so we
fix things up after the fact by copying the bitstream to the previously
used location/name for backwards compat.

Background:
Vivado has two ways of operating: project mode and non-project mode.
Project mode resembles what the UI does, and wraps a number of
individual commands in launch_runs commands. To hook up custom TCL
scripts between the subcommands, Vivado supports hooks. Hooks are TCL
scripts which are registered like this:

```
set_property STEPS.WRITE_BITSTREAM.TCL.PRE "vivado_hook.tcl" [get_runs impl_1]
```

Hook scripts only work in Vivado Project Mode; in Non-Project Mode,
users are expected to explicitly call their scripts at the right point
in the flow.

Edalize currently uses Vivado project flow for all but the last step of
the build: the bitstream generation. This allows hooks to work for all
steps but the WRITE_BITSTREAM one. That behavior is unexpected and easy
to avoid: include the bitstream generation in the launch_runs command
that does the implementation.

(Note: The project mode uses this command to write the bitstream:

```
write_bitstream -force toplevel_name.bit
```

So the `-force` flag is retained.