### PR TITLE
Vivado: Retry opening a device if it fails

### DIFF
--- a/edalize/templates/vivado/vivado-makefile.j2
+++ b/edalize/templates/vivado/vivado-makefile.j2
@@ -1,8 +1,10 @@
 NAME := {{ name }}
+BITSTREAM := {{ bitstream }}
+PART := {{ part }}
 
-all: $(NAME).bit
+all: $(BITSTREAM)
 
-$(NAME).bit:  $(NAME)_run.tcl $(NAME).xpr
+$(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
@@ -15,3 +17,8 @@ $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
+
+pgm: $(NAME)_pgm.tcl $(BITSTREAM)
+	vivado -quiet -nolog -notrace -mode batch -source $< -tclargs $(PART) $(BITSTREAM)
+
+.PHONY: pgm

--- a/edalize/templates/vivado/vivado-program.tcl.j2
+++ b/edalize/templates/vivado/vivado-program.tcl.j2
@@ -1,36 +1,73 @@
 # Auto-generated program tcl file
 
-set bit {{ bitstream_name }}
-set part {{ part }}
+set part [lindex $argv 0]
+set bitstream [lindex $argv 1]
 
+puts "FuseSoC Xilinx FPGA Programming Tool"
+puts "===================================="
+puts ""
+puts "INFO: Programming part $part with bitstream $bitstream"
+
+# Connect to Xilinx Hardware Server
 open_hw
 connect_hw_server
 
-set found 0
-
+# Find the first target and device that contains a FPGA $part.
+set hw_device_found 0
 foreach { hw_target } [get_hw_targets] {
+    puts "INFO: Trying to use hardware target $hw_target"
+
     current_hw_target $hw_target
-    if {[catch {open_hw_target} res_open_hw] == 0} {
-	foreach { hw_device } [get_hw_devices] {
-	    if { [string first [get_property PART $hw_device] $part] == 0 } {
-		puts "Found hardware target with a ${part} device."
-		current_hw_device $hw_device
-		set found 1
-		break
-	    }
-	}
-	if {$found} {break}
-    } else {
-	puts "Catched $res_open_hw"
+
+    # Open hardware target
+    # The Vivado hardware server isn't always able to reliably open a target.
+    # Try three times before giving up.
+    set hw_target_opened 0
+    for {set open_hw_target_try 1} {$open_hw_target_try <= 3} {incr open_hw_target_try} {
+        if {[catch {open_hw_target} res_open_hw_target] == 0} {
+            set hw_target_opened 1
+            break
+        }
     }
-    close_hw_target
+    if { $hw_target_opened == 0 } {
+        puts "WARNING: Unable to open hardware target $hw_target after " \
+            "$open_hw_target_try tries. Skipping."
+        continue
+    }
+    puts "INFO: Opened hardware target $hw_target on try $open_hw_target_try."
+
+    # Iterate through all devices and find one which contains $part
+    foreach { hw_device } [get_hw_devices] {
+        if { [string first [get_property PART $hw_device] $part] == 0 } {
+            puts "INFO: Found $part as part of $hw_device."
+            current_hw_device $hw_device
+            set hw_device_found 1
+            break
+        }
+    }
+
+    if { $hw_device_found == 1 } {
+        break
+    } else {
+        # Close currently tried device, and try with next one.
+        puts "INFO: Part not found as part of $hw_device. Trying next device."
+        close_hw_target
+    }
 }
-if { $found == 0 } {
-    puts "Did not find board with a ${part} device."
+if { $hw_device_found == 0 } {
+    puts "ERROR: None of the hardware targets included a $part FPGA part."
     exit 1
 }
+puts "INFO: Programming bitstream to device $hw_device on target $hw_target."
 
-set_property PROGRAM.FILE $bit [current_hw_device]
+# Do the programming
+current_hw_device $hw_device
+set_property PROGRAM.FILE $bitstream [current_hw_device]
 program_hw_devices [current_hw_device]
+
+# Disconnect from Xilinx Hardware Server
+close_hw_target
 disconnect_hw_server
 
+puts ""
+puts "INFO: SUCCESS! FPGA $part successfully programmed with bitstream $bitstream."

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -58,7 +58,7 @@ class Vivado(Edatool):
 
     """ Configuration is the first phase of the build
     This writes the project TCL files and Makefile. It first collects all
-    sources, IPs and contraints and then writes them to the TCL file along
+    sources, IPs and constraints and then writes them to the TCL file along
      with the build steps.
     """
     def configure_main(self):
@@ -88,7 +88,9 @@ class Vivado(Edatool):
 
         self.render_template('vivado-makefile.j2',
                              'Makefile',
-                             {'name' : self.name})
+                             {'name' : self.name,
+                              'part' : self.tool_options.get('part', ""),
+                              'bitstream' : self.name+'.bit'})
 
         self.render_template('vivado-run.tcl.j2',
                              self.name+"_run.tcl")
@@ -97,9 +99,7 @@ class Vivado(Edatool):
                              self.name+"_synth.tcl")
 
         self.render_template('vivado-program.tcl.j2',
-                             self.name+"_pgm.tcl",
-                             {'part' : self.tool_options.get('part', ""),
-                              'bitstream_name' : self.name+'.bit'})
+                             self.name+"_pgm.tcl")
 
     def src_file_filter(self, f):
         def _vhdl_source(f):
@@ -153,5 +153,4 @@ class Vivado(Edatool):
             elif self.tool_options['pnr'] == 'none':
                 return
 
-        self._run_tool('vivado', ['-mode', 'batch', '-source', self.name+"_pgm.tcl"])
-
+        self._run_tool('make', ['pgm'])

--- a/tests/test_vivado.py
+++ b/tests/test_vivado.py
@@ -20,6 +20,7 @@ def test_vivado():
         'Makefile',
         name+'.tcl',
         name+'_run.tcl',
+        name+'_pgm.tcl',
     ])
 
     backend.build()
@@ -39,10 +40,15 @@ def test_vivado_minimal():
     ref_dir      = os.path.join(tests_dir, __name__, 'minimal')
     os.environ['PATH'] = os.path.join(tests_dir, 'mock_commands')+':'+os.environ['PATH']
     tool = 'vivado'
+    tool_options = {
+        'part' : 'xc7a35tcsg324-1',
+    }
     name = 'test_vivado_minimal_0'
     work_root = tempfile.mkdtemp(prefix=tool+'_')
 
-    edam = {'name'         : name}
+    edam = {'name'         : name,
+            'tool_options' : {'vivado' : tool_options}
+    }
 
     backend = get_edatool(tool)(edam=edam, work_root=work_root)
     backend.configure([])
@@ -51,6 +57,7 @@ def test_vivado_minimal():
         'Makefile',
         name+'.tcl',
         name+'_run.tcl',
+        name+'_pgm.tcl',
     ])
 
     backend.build()

--- a/tests/test_vivado/Makefile
+++ b/tests/test_vivado/Makefile
@@ -1,8 +1,10 @@
 NAME := test_vivado_0
+BITSTREAM := test_vivado_0.bit
+PART := xc7a35tcsg324-1
 
-all: $(NAME).bit
+all: $(BITSTREAM)
 
-$(NAME).bit:  $(NAME)_run.tcl $(NAME).xpr
+$(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
@@ -15,3 +17,8 @@ $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
+
+pgm: $(NAME)_pgm.tcl $(BITSTREAM)
+	vivado -quiet -nolog -notrace -mode batch -source $< -tclargs $(PART) $(BITSTREAM)
+
+.PHONY: pgm

--- a/tests/test_vivado/minimal/Makefile
+++ b/tests/test_vivado/minimal/Makefile
@@ -1,8 +1,10 @@
 NAME := test_vivado_minimal_0
+BITSTREAM := test_vivado_minimal_0.bit
+PART := xc7a35tcsg324-1
 
-all: $(NAME).bit
+all: $(BITSTREAM)
 
-$(NAME).bit:  $(NAME)_run.tcl $(NAME).xpr
+$(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
@@ -15,3 +17,8 @@ $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
 	vivado -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
+
+pgm: $(NAME)_pgm.tcl $(BITSTREAM)
+	vivado -quiet -nolog -notrace -mode batch -source $< -tclargs $(PART) $(BITSTREAM)
+
+.PHONY: pgm

--- a/tests/test_vivado/minimal/test_vivado_minimal_0.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0.tcl
@@ -2,7 +2,7 @@
 
 create_project test_vivado_minimal_0 -force
 
-
+set_property part xc7a35tcsg324-1 [current_project]
 
 
 

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
@@ -1,36 +1,73 @@
 # Auto-generated program tcl file
 
-set bit test_vivado_minimal_0.bit
-set part xc7a35tcsg324-1
+set part [lindex $argv 0]
+set bitstream [lindex $argv 1]
 
+puts "FuseSoC Xilinx FPGA Programming Tool"
+puts "===================================="
+puts ""
+puts "INFO: Programming part $part with bitstream $bitstream"
+
+# Connect to Xilinx Hardware Server
 open_hw
 connect_hw_server
 
-set found 0
-
+# Find the first target and device that contains a FPGA $part.
+set hw_device_found 0
 foreach { hw_target } [get_hw_targets] {
+    puts "INFO: Trying to use hardware target $hw_target"
+
     current_hw_target $hw_target
-    if {[catch {open_hw_target} res_open_hw] == 0} {
-	foreach { hw_device } [get_hw_devices] {
-	    if { [string first [get_property PART $hw_device] $part] == 0 } {
-		puts "Found hardware target with a ${part} device."
-		current_hw_device $hw_device
-		set found 1
-		break
-	    }
-	}
-	if {$found} {break}
-    } else {
-	puts "Catched $res_open_hw"
+
+    # Open hardware target
+    # The Vivado hardware server isn't always able to reliably open a target.
+    # Try three times before giving up.
+    set hw_target_opened 0
+    for {set open_hw_target_try 1} {$open_hw_target_try <= 3} {incr open_hw_target_try} {
+        if {[catch {open_hw_target} res_open_hw_target] == 0} {
+            set hw_target_opened 1
+            break
+        }
     }
-    close_hw_target
+    if { $hw_target_opened == 0 } {
+        puts "WARNING: Unable to open hardware target $hw_target after " \
+            "$open_hw_target_try tries. Skipping."
+        continue
+    }
+    puts "INFO: Opened hardware target $hw_target on try $open_hw_target_try."
+
+    # Iterate through all devices and find one which contains $part
+    foreach { hw_device } [get_hw_devices] {
+        if { [string first [get_property PART $hw_device] $part] == 0 } {
+            puts "INFO: Found $part as part of $hw_device."
+            current_hw_device $hw_device
+            set hw_device_found 1
+            break
+        }
+    }
+
+    if { $hw_device_found == 1 } {
+        break
+    } else {
+        # Close currently tried device, and try with next one.
+        puts "INFO: Part not found as part of $hw_device. Trying next device."
+        close_hw_target
+    }
 }
-if { $found == 0 } {
-    puts "Did not find board with a ${part} device."
+if { $hw_device_found == 0 } {
+    puts "ERROR: None of the hardware targets included a $part FPGA part."
     exit 1
 }
+puts "INFO: Programming bitstream to device $hw_device on target $hw_target."
 
-set_property PROGRAM.FILE $bit [current_hw_device]
+# Do the programming
+current_hw_device $hw_device
+set_property PROGRAM.FILE $bitstream [current_hw_device]
 program_hw_devices [current_hw_device]
+
+# Disconnect from Xilinx Hardware Server
+close_hw_target
 disconnect_hw_server
 
+puts ""
+puts "INFO: SUCCESS! FPGA $part successfully programmed with bitstream $bitstream."

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
@@ -1,0 +1,36 @@
+# Auto-generated program tcl file
+
+set bit test_vivado_minimal_0.bit
+set part xc7a35tcsg324-1
+
+open_hw
+connect_hw_server
+
+set found 0
+
+foreach { hw_target } [get_hw_targets] {
+    current_hw_target $hw_target
+    if {[catch {open_hw_target} res_open_hw] == 0} {
+	foreach { hw_device } [get_hw_devices] {
+	    if { [string first [get_property PART $hw_device] $part] == 0 } {
+		puts "Found hardware target with a ${part} device."
+		current_hw_device $hw_device
+		set found 1
+		break
+	    }
+	}
+	if {$found} {break}
+    } else {
+	puts "Catched $res_open_hw"
+    }
+    close_hw_target
+}
+if { $found == 0 } {
+    puts "Did not find board with a ${part} device."
+    exit 1
+}
+
+set_property PROGRAM.FILE $bit [current_hw_device]
+program_hw_devices [current_hw_device]
+disconnect_hw_server
+

--- a/tests/test_vivado/test_vivado_0_pgm.tcl
+++ b/tests/test_vivado/test_vivado_0_pgm.tcl
@@ -1,36 +1,73 @@
 # Auto-generated program tcl file
 
-set bit test_vivado_0.bit
-set part xc7a35tcsg324-1
+set part [lindex $argv 0]
+set bitstream [lindex $argv 1]
 
+puts "FuseSoC Xilinx FPGA Programming Tool"
+puts "===================================="
+puts ""
+puts "INFO: Programming part $part with bitstream $bitstream"
+
+# Connect to Xilinx Hardware Server
 open_hw
 connect_hw_server
 
-set found 0
-
+# Find the first target and device that contains a FPGA $part.
+set hw_device_found 0
 foreach { hw_target } [get_hw_targets] {
+    puts "INFO: Trying to use hardware target $hw_target"
+
     current_hw_target $hw_target
-    if {[catch {open_hw_target} res_open_hw] == 0} {
-	foreach { hw_device } [get_hw_devices] {
-	    if { [string first [get_property PART $hw_device] $part] == 0 } {
-		puts "Found hardware target with a ${part} device."
-		current_hw_device $hw_device
-		set found 1
-		break
-	    }
-	}
-	if {$found} {break}
-    } else {
-	puts "Catched $res_open_hw"
+
+    # Open hardware target
+    # The Vivado hardware server isn't always able to reliably open a target.
+    # Try three times before giving up.
+    set hw_target_opened 0
+    for {set open_hw_target_try 1} {$open_hw_target_try <= 3} {incr open_hw_target_try} {
+        if {[catch {open_hw_target} res_open_hw_target] == 0} {
+            set hw_target_opened 1
+            break
+        }
     }
-    close_hw_target
+    if { $hw_target_opened == 0 } {
+        puts "WARNING: Unable to open hardware target $hw_target after " \
+            "$open_hw_target_try tries. Skipping."
+        continue
+    }
+    puts "INFO: Opened hardware target $hw_target on try $open_hw_target_try."
+
+    # Iterate through all devices and find one which contains $part
+    foreach { hw_device } [get_hw_devices] {
+        if { [string first [get_property PART $hw_device] $part] == 0 } {
+            puts "INFO: Found $part as part of $hw_device."
+            current_hw_device $hw_device
+            set hw_device_found 1
+            break
+        }
+    }
+
+    if { $hw_device_found == 1 } {
+        break
+    } else {
+        # Close currently tried device, and try with next one.
+        puts "INFO: Part not found as part of $hw_device. Trying next device."
+        close_hw_target
+    }
 }
-if { $found == 0 } {
-    puts "Did not find board with a ${part} device."
+if { $hw_device_found == 0 } {
+    puts "ERROR: None of the hardware targets included a $part FPGA part."
     exit 1
 }
+puts "INFO: Programming bitstream to device $hw_device on target $hw_target."
 
-set_property PROGRAM.FILE $bit [current_hw_device]
+# Do the programming
+current_hw_device $hw_device
+set_property PROGRAM.FILE $bitstream [current_hw_device]
 program_hw_devices [current_hw_device]
+
+# Disconnect from Xilinx Hardware Server
+close_hw_target
 disconnect_hw_server
 
+puts ""
+puts "INFO: SUCCESS! FPGA $part successfully programmed with bitstream $bitstream."

--- a/tests/test_vivado/test_vivado_0_pgm.tcl
+++ b/tests/test_vivado/test_vivado_0_pgm.tcl
@@ -1,0 +1,36 @@
+# Auto-generated program tcl file
+
+set bit test_vivado_0.bit
+set part xc7a35tcsg324-1
+
+open_hw
+connect_hw_server
+
+set found 0
+
+foreach { hw_target } [get_hw_targets] {
+    current_hw_target $hw_target
+    if {[catch {open_hw_target} res_open_hw] == 0} {
+	foreach { hw_device } [get_hw_devices] {
+	    if { [string first [get_property PART $hw_device] $part] == 0 } {
+		puts "Found hardware target with a ${part} device."
+		current_hw_device $hw_device
+		set found 1
+		break
+	    }
+	}
+	if {$found} {break}
+    } else {
+	puts "Catched $res_open_hw"
+    }
+    close_hw_target
+}
+if { $found == 0 } {
+    puts "Did not find board with a ${part} device."
+    exit 1
+}
+
+set_property PROGRAM.FILE $bit [current_hw_device]
+program_hw_devices [current_hw_device]
+disconnect_hw_server
+


### PR DESCRIPTION
Vivado isn't reliably opening a hardware device in v2018.3 (at least). Retry up to three times before giving up.

The first commit updates the tests to always include the `part` key, and check the programming TCL file as well.
The second commit then does the actual rewrite of the programming script.
Please see the individual commit messages for more details.

Both commits in one PR for easier merging, since they modify the same test files.