### PR TITLE
Vivado: Be more concise and helpful in outputs

### DIFF
--- a/edalize/templates/vivado/vivado-makefile.j2
+++ b/edalize/templates/vivado/vivado-makefile.j2
@@ -5,16 +5,16 @@ PART := {{ part }}
 all: $(BITSTREAM)
 
 $(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
-	vivado -mode batch -source $<
+	vivado -notrace -mode batch -source $<
 
 build-gui: $(NAME).xpr
 	vivado $<
 
 $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
 

--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -1,7 +1,17 @@
-launch_runs impl_1 -to_step write_bitstream
-wait_on_run impl_1
+# Vivado will raise an error if impl_1 is launched when it is already done. So
+# check the progress first and only launch if its not complete.
+if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  launch_runs impl_1 -to_step write_bitstream
+  wait_on_run impl_1
+  puts "Bitstream generation completed"
+} else {
+  puts "Bitstream generation already complete"
+}
 
-puts "Bitstream generation completed"
+if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+   puts "ERROR: Implementation and bitstream generation step failed."
+   exit 1
+}
 
 # By default, Vivado writes the bitstream to a file named after the toplevel and
 # put into the *.runs/impl_1 folder.

--- a/tests/test_vivado/Makefile
+++ b/tests/test_vivado/Makefile
@@ -5,16 +5,16 @@ PART := xc7a35tcsg324-1
 all: $(BITSTREAM)
 
 $(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
-	vivado -mode batch -source $<
+	vivado -notrace -mode batch -source $<
 
 build-gui: $(NAME).xpr
 	vivado $<
 
 $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
 

--- a/tests/test_vivado/minimal/Makefile
+++ b/tests/test_vivado/minimal/Makefile
@@ -5,16 +5,16 @@ PART := xc7a35tcsg324-1
 all: $(BITSTREAM)
 
 $(BITSTREAM):  $(NAME)_run.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 $(NAME).xpr: $(NAME).tcl
-	vivado -mode batch -source $<
+	vivado -notrace -mode batch -source $<
 
 build-gui: $(NAME).xpr
 	vivado $<
 
 $(NAME).runs/synth_1: $(NAME)_synth.tcl $(NAME).xpr
-	vivado -mode batch -source $^
+	vivado -notrace -mode batch -source $^
 
 synth: $(NAME).runs/synth_1
 

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
@@ -1,6 +1,11 @@
 launch_runs impl_1 -to_step write_bitstream
 wait_on_run impl_1
 
+if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+   puts "ERROR: Implementation and bitstream generation step failed."
+   exit 1
+}
+
 puts "Bitstream generation completed"
 
 # By default, Vivado writes the bitstream to a file named after the toplevel and

--- a/tests/test_vivado/minimal/vivado.cmd
+++ b/tests/test_vivado/minimal/vivado.cmd
@@ -1,2 +1,2 @@
--mode batch -source test_vivado_minimal_0.tcl
--mode batch -source test_vivado_minimal_0_run.tcl test_vivado_minimal_0.xpr
+-notrace -mode batch -source test_vivado_minimal_0.tcl
+-notrace -mode batch -source test_vivado_minimal_0_run.tcl test_vivado_minimal_0.xpr

--- a/tests/test_vivado/test_vivado_0_run.tcl
+++ b/tests/test_vivado/test_vivado_0_run.tcl
@@ -1,6 +1,11 @@
 launch_runs impl_1 -to_step write_bitstream
 wait_on_run impl_1
 
+if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+   puts "ERROR: Implementation and bitstream generation step failed."
+   exit 1
+}
+
 puts "Bitstream generation completed"
 
 # By default, Vivado writes the bitstream to a file named after the toplevel and

--- a/tests/test_vivado/vivado.cmd
+++ b/tests/test_vivado/vivado.cmd
@@ -1,2 +1,2 @@
--mode batch -source test_vivado_0.tcl
--mode batch -source test_vivado_0_run.tcl test_vivado_0.xpr
+-notrace -mode batch -source test_vivado_0.tcl
+-notrace -mode batch -source test_vivado_0_run.tcl test_vivado_0.xpr


### PR DESCRIPTION
Don't run Vivado in "tracing mode", which is similar to "set -x" in
bash: it dumps all parts of the script, including non-executed lines.
This behavior is especially confusing if Vivado dumps code which says
"ERROR: ...", but then this code is actually never executed. In
non-tracing mode, this source of confusion is removed.

As second enhancement, check if the implementation step succeeded before
telling users about it. The rather ugly comparison to "100%" is what
Xilinx proposes to use in their TCL reference guide, section
wait_on_run.

For an arbitrary example (with a hook that fails implementation), you
get the following behavior before and after this change.

Before:

```
source /your/folder/build/toplevel/synth-vivado/vivado_hook_opt_design_post.tcl
INFO: [Designcheck 1-1] Checking if ROM memory is mapped to BRAM memory.
WARNING: [Vivado 12-180] No cells matched 'get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }'.
ERROR: [Designcheck 1-2] BRAM implementation not found for ROM memory.
ERROR: [runtcl-1] ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.
ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.

INFO: [Common 17-206] Exiting Vivado at Thu Oct 31 11:26:19 2019...
[Thu Oct 31 11:26:19 2019] impl_1 finished
wait_on_run: Time (s): cpu = 00:05:40 ; elapsed = 00:06:08 . Memory (MB): peak = 1351.699 ; gain = 0.000 ; free physical = 8259 ; free virtual = 31743
ERROR: Implementation and bitstream generation step failed.
    while executing
"error "ERROR: Implementation and bitstream generation step failed.""
    invoked from within
"if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
   error "ERROR: Implementation and bitstream generation step failed."
}"
    (file "toplevel_run.tcl" line 4)
INFO: [Common 17-206] Exiting Vivado at Thu Oct 31 11:26:19 2019...
make: *** [Makefile:8: toplevel.bit] Fehler 1
```

After:

```
source /your/folder/build/toplevel/synth-vivado/vivado_hook_opt_design_post.tcl
INFO: [Designcheck 1-1] Checking if ROM memory is mapped to BRAM memory.
WARNING: [Vivado 12-180] No cells matched 'get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }'.
ERROR: [Designcheck 1-2] BRAM implementation not found for ROM memory.
ERROR: [runtcl-1] ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.
ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.

INFO: [Common 17-206] Exiting Vivado at Thu Oct 31 11:43:41 2019...
[Thu Oct 31 11:43:41 2019] impl_1 finished
wait_on_run: Time (s): cpu = 00:05:04 ; elapsed = 00:05:40 . Memory (MB): peak = 1351.699 ; gain = 0.000 ; free physical = 7151 ; free virtual = 31011
ERROR: Implementation and bitstream generation step failed.
INFO: [Common 17-206] Exiting Vivado at Thu Oct 31 11:43:41 2019...
make: *** [Makefile:8: toplevel.bit] Fehler 1
```