### PR TITLE
Quartus synth only option

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -32,7 +32,10 @@ class Quartus(Edatool):
                          'desc' : 'FPGA device (e.g. 5CSXFC6D6F31C8ES)'},
                         {'name' : 'board_device_index',
                          'type' : 'String',
-                         'desc' : "Specifies the FPGA's device number in the JTAG chain. The device index specifies the device where the flash programmer looks for the Nios® II JTAG debug module. JTAG devices are numbered relative to the JTAG chain, starting at 1. Use the tool `jtagconfig` to determine the index."}],
+                         'desc' : "Specifies the FPGA's device number in the JTAG chain. The device index specifies the device where the flash programmer looks for the Nios® II JTAG debug module. JTAG devices are numbered relative to the JTAG chain, starting at 1. Use the tool `jtagconfig` to determine the index."},
+                        {'name' : 'pnr',
+                         'type' : 'String',
+                         'desc' : 'P&R tool. Allowed values are quartus (default) and none (to just run synthesis)'}],
                     'lists' : [
                         {'name' : 'quartus_options',
                          'type' : 'String',
@@ -144,7 +147,7 @@ class Quartus(Edatool):
                 except (AttributeError, KeyError):
                     # Either a component wasn't found in the QSYS file, or it
                     # had no associated tool information. Make the assumption
-                    # it was a Standard edition file 
+                    # it was a Standard edition file
                     if not self.isPro:
                         name = f.name
             except (ET.ParseError, IOError):
@@ -210,12 +213,29 @@ class Quartus(Edatool):
 
         return ''
 
+
+    def build_main(self):
+        logger.info("Building")
+        args = []
+        if 'pnr' in self.tool_options:
+            if self.tool_options['pnr'] == 'quartus':
+                pass
+            elif self.tool_options['pnr'] == 'none':
+                args.append('syn')
+        self._run_tool('make', args)
+
     """ Program the FPGA
     """
     def run_main(self):
         args = ['--mode=jtag']
         args += ['-o']
         args += ['p;' + self.name.replace('.', '_') + '.sof']
+
+        if 'pnr' in self.tool_options:
+            if self.tool_options['pnr'] == 'quartus':
+                pass
+            elif self.tool_options['pnr'] == 'none':
+                return
 
         if 'board_device_index' in self.tool_options:
             args[-1] += "@" + self.tool_options['board_device_index']

--- a/edalize/templates/quartus/quartus-std-makefile.j2
+++ b/edalize/templates/quartus/quartus-std-makefile.j2
@@ -13,7 +13,7 @@ qsys: project
 	ip-generate --project-directory={{qsys_file.srcdir}} --output-directory={{qsys_file.dstdir}}/synthesis --file-set=QUARTUS_SYNTH --report-file=sopcinfo:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.sopcinfo --report-file=html:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.html --report-file=qip:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.qip --report-file=cmp:{{qsys_file.dstdir}}/{{qsys_file.simplename}}.cmp --report-file=svd --system-info=DEVICE_FAMILY="{{tool_options.family}}" --system-info=DEVICE={{tool_options.device}} --component-file={{qsys_file.srcdir}}/{{qsys_file.simplename}}.qsys --language=VERILOG
 {% endfor %}
 
-map: qsys
+syn: qsys
 	quartus_map $(OPTIONS) $(NAME)
 
 fit: map

--- a/edalize/templates/quartus/quartus-std-makefile.j2
+++ b/edalize/templates/quartus/quartus-std-makefile.j2
@@ -16,7 +16,7 @@ qsys: project
 syn: qsys
 	quartus_map $(OPTIONS) $(NAME)
 
-fit: map
+fit: syn
 	quartus_fit $(OPTIONS) $(NAME)
 
 asm: fit

--- a/tests/test_quartus/Standard/Makefile
+++ b/tests/test_quartus/Standard/Makefile
@@ -11,10 +11,10 @@ qsys: project
 	ip-generate --project-directory= --output-directory=qsys/qsys_file --report-file=bsf:qsys/qsys_file/qsys_file.bsf --system-info=DEVICE_FAMILY="Cyclone V" --system-info=DEVICE=5CSXFC6D6F31C8ES --component-file=/qsys_file.qsys
 	ip-generate --project-directory= --output-directory=qsys/qsys_file/synthesis --file-set=QUARTUS_SYNTH --report-file=sopcinfo:qsys/qsys_file/qsys_file.sopcinfo --report-file=html:qsys/qsys_file/qsys_file.html --report-file=qip:qsys/qsys_file/qsys_file.qip --report-file=cmp:qsys/qsys_file/qsys_file.cmp --report-file=svd --system-info=DEVICE_FAMILY="Cyclone V" --system-info=DEVICE=5CSXFC6D6F31C8ES --component-file=/qsys_file.qsys --language=VERILOG
 
-map: qsys
+syn: qsys
 	quartus_map $(OPTIONS) $(NAME)
 
-fit: map
+fit: syn
 	quartus_fit $(OPTIONS) $(NAME)
 
 asm: fit


### PR DESCRIPTION
As described in #63, allow Quartus to support synthesis-only runs by using the same `pnr` tool option that is available for Vivado.