### PR TITLE
Improve documentation; render module API docs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,8 @@
 from datetime import datetime
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../edalize'))
+sys.path.insert(0, os.path.abspath('../../edalize'))
+sys.path.insert(0, os.path.abspath('../../edalize/tests/test_vunit/vunit_mock/'))
 
 
 # -- Project information -----------------------------------------------------
@@ -43,6 +44,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -71,6 +73,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
+
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'vunit': ('https://vunit.github.io/', None)}
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -169,7 +174,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'Edalize', 'Edalize Documentation',
-     author, 'Edalize', 'One line description of project.',
+     author, 'Edalize', 'Edalize is a Python Library for interacting with EDA tools.',
      'Miscellaneous'),
 ]
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+vunit_hdl
+sphinx_rtd_theme

--- a/doc/source/edalize.rst
+++ b/doc/source/edalize.rst
@@ -117,9 +117,17 @@ edalize.vivado module
     :show-inheritance:
 
 edalize.vunit module
-------------------
+--------------------
 
 .. automodule:: edalize.vunit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+edalize.vunit_hooks module
+--------------------------
+
+.. automodule:: edalize.vunit_hooks
     :members:
     :undoc-members:
     :show-inheritance:

--- a/edalize/vunit_hooks.py
+++ b/edalize/vunit_hooks.py
@@ -20,7 +20,7 @@ class VUnitHooks(object):
         pass
 
     def main(self, vu: VUnit):
-        """Override this for final parametrization of the :class:`~edalize.vunit.Vunit` instance, or for custom invocation of VUnit."""
+        """Override this for final parametrization of the :class:`~vunit.ui.VUnit` instance, or for custom invocation of VUnit."""
         vu.main()
 
 

--- a/edalize/vunit_hooks.py
+++ b/edalize/vunit_hooks.py
@@ -1,4 +1,4 @@
-"""This module exports :class:`VUnitHooks` which can be used to implement advanced VUnit test cases"""
+"""This module exports :class:`VUnitHooks` which can be used to implement advanced VUnit test cases."""
 
 from vunit.ui import Library
 from vunit import VUnit
@@ -6,25 +6,24 @@ from typing import Mapping, Collection
 
 
 class VUnitHooks(object):
-    """Derive the :class:`VUnitRunner` instance from this class and override its member functions if necessary"""
+    """Derive the :class:`VUnitRunner` instance from this class and override its member functions if necessary."""
 
     def __init__(self):
         pass
 
     def create(self) -> VUnit:
-        """Override this function to specify custom instantiation of VUnit"""
+        """Override this function to specify custom instantiation of VUnit."""
         return VUnit.from_argv()
 
     def handle_library(self, logical_name: str, vu_lib: Library):
-        """override this to customize each library, e.g. with additional simulator options"""
+        """Override this to customize each library, e.g. with additional simulator options."""
         pass
 
     def main(self, vu: VUnit):
-        """override this for final parametrization of the :class:`VUnit` instance, or for custom invokation of VUnit"""
+        """Override this for final parametrization of the :class:`~edalize.vunit.Vunit` instance, or for custom invocation of VUnit."""
         vu.main()
 
 
 class VUnitRunner(VUnitHooks):
-    """The default runner which will be used if no `vunit_runner.py` is specified"""
-
+    """The default runner which will be used if no :file:`vunit_runner.py` is specified."""
     pass


### PR DESCRIPTION
This will render the missing content from here: https://edalize.readthedocs.io/en/latest/source/edalize.html

@julian-becker The type annotations said it should be ``class VUnit(Edatool):``, with an uppercase U, so I fixed that - correct?