### PR TITLE
Icestorm tweaks

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -124,9 +124,9 @@ class Edatool(object):
         if 'pre_build' in self.hooks:
             self._run_scripts(self.hooks['pre_build'], 'pre_build')
 
-    def build_main(self):
-        logger.info("Building");
-        self._run_tool('make')
+    def build_main(self, target=None):
+        logger.info("Building{}".format("" if target is None else "target " + " ".join(target)))
+        self._run_tool('make', [] if target is None else [target])
 
     def build_post(self):
         if 'post_build' in self.hooks:

--- a/edalize/icestorm.py
+++ b/edalize/icestorm.py
@@ -73,6 +73,7 @@ class Icestorm(Edatool):
             raise RuntimeError("Icestorm backend supports only one PCF file. Found {}".format(', '.join(pcf_files)))
 
         pnr = self.tool_options.get('pnr', 'arachne')
+        part = self.tool_options.get('part', None)
         if not pnr in ['arachne', 'next', 'none']:
             raise RuntimeError("Invalid pnr option '{}'. Valid values are 'arachne' for Arachne-pnr or 'next' for nextpnr".format(pnr))
         # Write Makefile
@@ -85,6 +86,7 @@ class Icestorm(Edatool):
             'arachne_pnr_options' : arachne_pnr_options,
             'nextpnr_options'     : nextpnr_options,
             'default_target'      : 'json' if pnr == 'none' else 'bin',
+            'device'              : part,
         }
         self.render_template('icestorm-makefile.j2',
                              'Makefile',

--- a/edalize/templates/icestorm/icestorm-makefile.j2
+++ b/edalize/templates/icestorm/icestorm-makefile.j2
@@ -5,8 +5,13 @@ PCF_FILE := {{ pcf_file }}
 PNR      ?= {{ pnr }}
 ARACHNE_PNR_OPTIONS := {{ arachne_pnr_options|join(' ') }}
 NEXTPNR_OPTIONS     := {{ nextpnr_options|join(' ') }}
+DEVICE   := {{ device }}
 
 all: $(TARGET).{{ default_target }}
+timing: $(TARGET).tim
+stats: $(TARGET).stat
+
+.PRECIOUS: %_next.asc %_arachne.asc
 
 %.blif: %.ys
 	yosys -l yosys.log -q -s $?
@@ -18,6 +23,10 @@ all: $(TARGET).{{ default_target }}
 	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
+%.tim: %_$(PNR).asc
+	icetime -tmd $(DEVICE) $< > $@
+%.stat: %_$(PNR).asc
+	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
 	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui

--- a/tests/test_icestorm/Makefile
+++ b/tests/test_icestorm/Makefile
@@ -5,8 +5,13 @@ PCF_FILE := pcf_file.pcf
 PNR      ?= arachne
 ARACHNE_PNR_OPTIONS := a few arachne_pnr_options
 NEXTPNR_OPTIONS     := 
+DEVICE   := None
 
 all: $(TARGET).bin
+timing: $(TARGET).tim
+stats: $(TARGET).stat
+
+.PRECIOUS: %_next.asc %_arachne.asc
 
 %.blif: %.ys
 	yosys -l yosys.log -q -s $?
@@ -18,6 +23,10 @@ all: $(TARGET).bin
 	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
+%.tim: %_$(PNR).asc
+	icetime -tmd $(DEVICE) $< > $@
+%.stat: %_$(PNR).asc
+	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
 	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui

--- a/tests/test_icestorm/minimal/Makefile
+++ b/tests/test_icestorm/minimal/Makefile
@@ -5,8 +5,13 @@ PCF_FILE := pcf_file.pcf
 PNR      ?= arachne
 ARACHNE_PNR_OPTIONS := 
 NEXTPNR_OPTIONS     := 
+DEVICE   := None
 
 all: $(TARGET).bin
+timing: $(TARGET).tim
+stats: $(TARGET).stat
+
+.PRECIOUS: %_next.asc %_arachne.asc
 
 %.blif: %.ys
 	yosys -l yosys.log -q -s $?
@@ -18,6 +23,10 @@ all: $(TARGET).bin
 	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
+%.tim: %_$(PNR).asc
+	icetime -tmd $(DEVICE) $< > $@
+%.stat: %_$(PNR).asc
+	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
 	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui

--- a/tests/test_icestorm/nextpnr/Makefile
+++ b/tests/test_icestorm/nextpnr/Makefile
@@ -5,8 +5,13 @@ PCF_FILE := pcf_file.pcf
 PNR      ?= next
 ARACHNE_PNR_OPTIONS := a few arachne_pnr_options
 NEXTPNR_OPTIONS     := multiple nextpnr_options
+DEVICE   := None
 
 all: $(TARGET).bin
+timing: $(TARGET).tim
+stats: $(TARGET).stat
+
+.PRECIOUS: %_next.asc %_arachne.asc
 
 %.blif: %.ys
 	yosys -l yosys.log -q -s $?
@@ -18,6 +23,10 @@ all: $(TARGET).bin
 	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
+%.tim: %_$(PNR).asc
+	icetime -tmd $(DEVICE) $< > $@
+%.stat: %_$(PNR).asc
+	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
 	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui


### PR DESCRIPTION
this PR adds two additional targets to Makefiles generated for icestorm toolchain:

* `timing` - timing report generation with the `icetime` tool
* `stats` - logic usage report generation using `icestat` tool

Those targets are not called when `build()` is called.
Also, the PR adds a simple mechanism for calling the additional targets - user may now pass a target name to `build_main` function e.g:

```
self.backend = edalize.get_edatool('icestorm')(edam=self.edam, work_root=self.out_dir)
self.backend.configure("")
self.backend.build()
self.backend.build_main('timing')
``` 

If this mechanism is OK I can work on adding similar targets to other toolchains