### PR TITLE
modelsim: Add vcom_options

### DIFF
--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -73,6 +73,9 @@ class Modelsim(Edatool):
         if api_ver == 0:
             return {'description' : "ModelSim simulator from Mentor Graphics",
                     'lists' : [
+                        {'name' : 'vcom_options',
+                         'type' : 'String',
+                         'desc' : 'Additional options for compilation with vcom'},
                         {'name' : 'vlog_options',
                          'type' : 'String',
                          'desc' : 'Additional options for compilation with vlog'},
@@ -117,6 +120,9 @@ class Modelsim(Edatool):
                     args = ['-2008']
                 else:
                     args = []
+
+                args += self.tool_options.get('vcom_options', [])
+
             elif f.file_type == 'tclSource':
                 cmd = None
                 tcl_main.write("do {}\n".format(f.name))

--- a/tests/test_modelsim.py
+++ b/tests/test_modelsim.py
@@ -10,6 +10,7 @@ def test_modelsim():
     name         = 'test_modelsim_0'
     tool         = 'modelsim'
     tool_options = {
+        'vcom_options' : ['various', 'vcom_options'],
         'vlog_options' : ['some', 'vlog_options'],
         'vsim_options' : ['a', 'few', 'vsim_options'],
     }

--- a/tests/test_modelsim/edalize_build_rtl.tcl
+++ b/tests/test_modelsim/edalize_build_rtl.tcl
@@ -2,7 +2,7 @@ vlib work
 vlog some vlog_options +define+vlogdefine_bool=1 +define+vlogdefine_int=42 +define+vlogdefine_str=hello -sv +incdir+. -quiet -work work sv_file.sv
 vlog some vlog_options +define+vlogdefine_bool=1 +define+vlogdefine_int=42 +define+vlogdefine_str=hello +incdir+. -quiet -work work vlog_file.v
 vlog some vlog_options +define+vlogdefine_bool=1 +define+vlogdefine_int=42 +define+vlogdefine_str=hello +incdir+. -quiet -work work vlog05_file.v
-vcom -quiet -work work vhdl_file.vhd
+vcom various vcom_options -quiet -work work vhdl_file.vhd
 vlib libx
-vcom -quiet -work libx vhdl_lfile
-vcom -2008 -quiet -work work vhdl2008_file
+vcom various vcom_options -quiet -work libx vhdl_lfile
+vcom -2008 various vcom_options -quiet -work work vhdl2008_file


### PR DESCRIPTION
Allow options to be passed to ModelSim's `vcom` command.