### PR TITLE
Vivado: create a .bin file for programming flash

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -1,3 +1,6 @@
+# Create a bin file which can be used to program the flash on the FPGA
+set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
@@ -1,3 +1,6 @@
+# Create a bin file which can be used to program the flash on the FPGA
+set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {

--- a/tests/test_vivado/test_vivado_0_run.tcl
+++ b/tests/test_vivado/test_vivado_0_run.tcl
@@ -1,3 +1,6 @@
+# Create a bin file which can be used to program the flash on the FPGA
+set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {


### PR DESCRIPTION
A .bin file appears to just be a .bit file with the header stripped, but
Vivado requires it to program flash devices.