### PR TITLE
Vivado file handling improvements

### DIFF
--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -123,13 +123,14 @@ class Vivado(Edatool):
         _file_type = f.file_type.split('-')[0]
         if _file_type in file_types:
             return file_types[_file_type] + ' ' + f.name
-        elif _file_type == 'user':
+
+        if _file_type == 'user':
             return ''
-        else:
-            _s = "{} has unknown file type '{}'"
-            logger.warning(_s.format(f.name,
-                                     f.file_type))
-        return ''
+
+        _s = "{} has unknown file type '{}', interpretation is up to Vivado"
+        logger.warning(_s.format(f.name,
+                                    f.file_type))
+        return 'add_files -norecurse' + ' ' + f.name
 
     def build_main(self):
         logger.info("Building")

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -118,6 +118,7 @@ class Vivado(Edatool):
             'xdc'                 : 'read_xdc',
             'tclSource'           : 'source',
             'SDC'                 : 'read_xdc -unmanaged',
+            'mem'                 : 'read_mem',
         }
         _file_type = f.file_type.split('-')[0]
         if _file_type in file_types:

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -51,7 +51,7 @@ class Vivado(Edatool):
             match = re.search(version_exp, str(vivado_text))
             if match is not None:
                 version = match.group('version')
-        except Exception as ex:
+        except Exception:
             logger.warning("Unable to recognize Vivado version")
 
         return version

--- a/tests/edalize_common.py
+++ b/tests/edalize_common.py
@@ -96,7 +96,8 @@ files = [
     {'name' : 'vhdl_lfile'   , 'file_type' : 'vhdlSource', 'logical_name' : 'libx'},
     {'name' : 'vhdl2008_file', 'file_type' : 'vhdlSource-2008'},
     {'name' : 'xci_file.xci' , 'file_type' : 'xci'},
-    {'name' : 'xdc_file.xdc' , 'file_type' : 'xdc'}
+    {'name' : 'xdc_file.xdc' , 'file_type' : 'xdc'},
+    {'name' : 'bootrom.mem'  , 'file_type' : 'mem'},
 ]
 
 vpi = [
@@ -109,4 +110,3 @@ vpi = [
      'include_dirs': [],
      'libs': [],
      'name': 'vpi2'}]
-    

--- a/tests/test_vivado/test_vivado_0.tcl
+++ b/tests/test_vivado/test_vivado_0.tcl
@@ -8,8 +8,13 @@ set_param project.enableVHDL2008 1
 set_property generic {vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello } [get_filesets sources_1]
 set_property generic {generic_bool=true generic_int=42 generic_str=hello } [get_filesets sources_1]
 set_property verilog_define {vlogdefine_bool=1 vlogdefine_int=42 vlogdefine_str=hello } [get_filesets sources_1]
+add_files -norecurse qip_file.qip
+add_files -norecurse qsys_file
 read_xdc -unmanaged sdc_file
+add_files -norecurse bmm_file
 read_verilog -sv sv_file.sv
+add_files -norecurse pcf_file.pcf
+add_files -norecurse ucf_file.ucf
 source tcl_file.tcl
 read_verilog vlog_file.v
 read_verilog vlog05_file.v

--- a/tests/test_vivado/test_vivado_0.tcl
+++ b/tests/test_vivado/test_vivado_0.tcl
@@ -18,6 +18,7 @@ read_vhdl -library libx vhdl_lfile
 read_vhdl -vhdl2008 vhdl2008_file
 read_ip xci_file.xci
 read_xdc xdc_file.xdc
+read_mem bootrom.mem
 
 set_property include_dirs [list . .] [get_filesets sources_1]
 set_property top top_module [current_fileset]


### PR DESCRIPTION
- Explicitly handle `mem` files (memory initialization, e.g. for `$readmemh()`.
- Pass all unknown file types thorugh to Vivado.

The second change might be slightly controversial, but it makes users of edalize much happier: it is annoying not to be able functionality in Vivado without patching edalize first, and no easy workaround available.