### PR TITLE
Fix sys.path in Sphinx config.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,8 +15,8 @@
 from datetime import datetime
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../edalize'))
-sys.path.insert(0, os.path.abspath('../../edalize/tests/test_vunit/vunit_mock/'))
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../tests/test_vunit/vunit_mock/'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
PR #79 did not render in ReadTheDocs despite working locally on my machine, probably because the relative ``sys.path`` in the Sphinx config tried to go up two directory levels which apparently doesn't exist in the RTD file system.
This PR fixes the problem as can be seen in https://cmarqu-edalize.readthedocs.io/en/latest/source/edalize.html#edalize.vunit_hooks.VUnitHooks