### PR TITLE
Behavior change in lstrip_blocks in Jinja 2.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup(
     ],
     install_requires=[
         'pytest>=3.3.0',
-        'Jinja2>=2.8',
+        # Avoid Jinja 2.11 until https://github.com/pallets/jinja/issues/1138
+        # is sorted.
+        'Jinja2 >=2.8, <2.11',
     ],
     tests_require=[
         'pyyaml',


### PR DESCRIPTION
Jinja 2.11.0 got released a couple days ago, and it changed the behavior
of lstrip_blocks. This breaks some templates.

It's not yet clear if we misunderstood the lstrip_blocks documentation
(and things were never expected to work that way), or if Jinja2
introduced a breaking change.

Upstream bug report https://github.com/pallets/jinja/issues/1138