### PR TITLE
Add Verible lint backend

### DIFF
--- a/edalize/veriblelint.py
+++ b/edalize/veriblelint.py
@@ -1,0 +1,76 @@
+import logging
+import re
+import os
+import subprocess
+
+from edalize.edatool import Edatool
+
+logger = logging.getLogger(__name__)
+
+class Veriblelint(Edatool):
+
+    argtypes = ['vlogdefine', 'vlogparam']
+
+    @classmethod
+    def get_doc(cls, api_ver):
+        if api_ver == 0:
+            return {'description' : "Verible lint backend (verilog_lint)",
+                    'members': [
+                         {'name': 'ruleset',
+                          'type': 'String',
+                          'desc': 'Ruleset: [default|all|none]'},
+                    ],
+                    'lists': [
+                         {'name' : 'verible_lint_args',
+                         'type' : 'String',
+                         'desc' : 'Extra command line arguments passed to the Verible tool'},
+                         {'name': 'rules',
+                          'type': 'String',
+                          'desc': 'What rules to use. Prefix a rule name with "-" to disable it.'},
+                    ]}
+
+
+    def build_main(self):
+        pass
+
+    def _get_tool_args(self):
+        args = [ '-lint_fatal', '-parse_fatal' ]
+
+        if 'rules' in self.tool_options:
+            args.append('-rules=' + ','.join(self.tool_options['rules']))
+        if 'ruleset' in self.tool_options:
+            args.append('-ruleset=' + self.tool_options['ruleset'])
+        if 'verible_lint_args' in self.tool_options:
+            args += self.tool_options['verible_lint_args']
+
+        return args
+
+    def run_main(self):
+        (src_files, incdirs) = self._get_fileset_files(force_slash=True)
+
+        src_files_filtered = []
+        for src_file in src_files:
+            ft = src_file.file_type
+            if not ft.startswith("verilogSource") and not ft.startswith("systemVerilogSource"):
+                continue
+            src_files_filtered.append(src_file.name)
+
+        if len(src_files_filtered) == 0:
+            logger.warning("No SystemVerilog source files to be processed.")
+            return
+
+        lint_fail = False
+        for src_file in src_files_filtered:
+            cmd = ['verilog_lint'] + self._get_tool_args() + [src_file]
+            logger.debug("Running " + ' '.join(cmd))
+
+            try:
+                res = subprocess.run(cmd, cwd = self.work_root, check=False)
+            except FileNotFoundError:
+                _s = "Command '{}' not found. Make sure it is in $PATH"
+                raise RuntimeError(_s.format(cmd[0]))
+
+            if res.returncode != 0:
+                lint_fail = True
+        if lint_fail:
+            raise RuntimeError("Lint failed")

--- a/tests/mock_commands/verilog_lint
+++ b/tests/mock_commands/verilog_lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+import sys
+
+with open('verilog_lint.cmd', 'a') as f:
+    f.write(' '.join(sys.argv[1:]) + '\n')

--- a/tests/test_veriblelint.py
+++ b/tests/test_veriblelint.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def test_veriblelint_default():
+    """ Test the lint mode of Verible """
+    import os
+    import shutil
+    from edalize_common import compare_files, setup_backend, tests_dir
+
+    ref_dir = os.path.join(tests_dir, __name__, 'lint')
+    paramtypes = ['vlogdefine', 'vlogparam']
+    name = 'test_verible'
+    tool = 'veriblelint'
+    tool_options = {}
+
+    (backend, args, work_root) = setup_backend(
+        paramtypes, name, tool, tool_options)
+    backend.configure(args)
+    backend.build()
+    backend.run(args)
+    compare_files(ref_dir, work_root, [
+        'verilog_lint.cmd',
+    ])

--- a/tests/test_veriblelint/lint/verilog_lint.cmd
+++ b/tests/test_veriblelint/lint/verilog_lint.cmd
@@ -1,0 +1,3 @@
+-lint_fatal -parse_fatal sv_file.sv
+-lint_fatal -parse_fatal vlog_file.v
+-lint_fatal -parse_fatal vlog05_file.v


### PR DESCRIPTION
This backend can do verible lint only for now (no verible format).

I initially tried to do verilog_lint and verilog_format in one backend, but that turns out to be too messy, as we want actually different tool options for lint and format (e.g. the "rules" or "ruleset" options don't make sense for verilog_format).

So going with lint-only for now, looking into Verible format later.

Fixes #95