### PR TITLE
README.rst : adding python install method and import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ Ok, this sounds great. Now, how do I get started?
 
 Assume we have a project that consists of a Verilog source file called ``blinky.v``.
 Then there's also a testbench called ``blinky_tb.v`` and a constraints file for synthesis called ``constraints.sdc``.
-You can get those files from `blinky https://github.com/fusesoc/blinky`_ and for
-``vlog_tb_utils.v`` in `orpsoc-cores https://github.com/openrisc/orpsoc-cores/blob/master/cores/vlog_tb_utils/vlog_tb_utils.v`_
+You can get those files from `blinky <https://github.com/fusesoc/blinky>`_ and for
+``vlog_tb_utils.v`` in `orpsoc-cores <https://github.com/openrisc/orpsoc-cores/blob/master/cores/vlog_tb_utils/vlog_tb_utils.v>`_
 
 For a simulation, we want to use the two Verilog files, build it in a subdirectory called ``build``, and then run it with a parameter to control simulated clock frequency.
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,16 @@ It can also be used to just get a quick template that you can open up in the too
 
 It can be directly integrated as a library for your existing Python-powered HDL project, or can be used stand-alone (soon anyway) to feed Edalize from projects written in other languages.
 
+Install it
+----------
+
+Edalize is a python module. Then once downloaded we can install it with
+following python command::
+
+    $ cd edalize
+    $ python -m pip install -e .
+
+
 How to use it?
 --------------
 
@@ -35,7 +45,18 @@ You can get those files from here: https://github.com/fusesoc/blinky
 
 For a simulation, we want to use the two Verilog files, build it in a subdirectory called ``build``, and then run it with a parameter to control simulated clock frequency.
 
-First we register the files to use::
+Edalize is a python tool, then we can run it inside a python script file or
+directly in python console.
+
+First we have to import edalize objects::
+
+  from edalize import *
+
+os module is also required for this tutorial::
+
+  import os
+
+then register the files to use::
 
   work_root = 'build'
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ Ok, this sounds great. Now, how do I get started?
 
 Assume we have a project that consists of a Verilog source file called ``blinky.v``.
 Then there's also a testbench called ``blinky_tb.v`` and a constraints file for synthesis called ``constraints.sdc``.
-You can get those files from here: https://github.com/fusesoc/blinky
+You can get those files from `blinky https://github.com/fusesoc/blinky`_ and for
+``vlog_tb_utils.v`` in `orpsoc-cores https://github.com/openrisc/orpsoc-cores/blob/master/cores/vlog_tb_utils/vlog_tb_utils.v`_
 
 For a simulation, we want to use the two Verilog files, build it in a subdirectory called ``build``, and then run it with a parameter to control simulated clock frequency.
 
@@ -64,6 +65,8 @@ then register the files to use::
     {'name' : os.path.relpath('blinky.v', work_root),
      'file_type' : 'verilogSource'},
     {'name' : os.path.relpath('blinky_tb.v', work_root),
+     'file_type' : 'verilogSource'},
+    {'name' : os.path.relpath('vlog_tb_utils.v', work_root),
      'file_type' : 'verilogSource'}
   ]
 


### PR DESCRIPTION
Intro readme proposal to explain that it's a python module and we have to import it at the begining.

I didn't managed to execute the tutorial because of vlog_tb_utils() dependancy.

```
Instantiate backend
configure
build
iverilog -sblinky_tb -c blinky_project.scr -o blinky_project 
../blinky_tb.v:15: error: Unknown module type: vlog_tb_utils
2 error(s) during elaboration.
*** These modules were missing:
        vlog_tb_utils referenced 1 times.
***
Makefile:8: recipe for target 'blinky_project' failed
make: *** [blinky_project] Error 2
Traceback (most recent call last):
  File "/home/fabien/myfpga/edalize/edalize/edatool.py", line 300, in _run_tool
    stdin=subprocess.PIPE),
  File "/usr/local/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make']' returned non-zero exit status 2.

During handling of the above exception, another exception occurred:
```
 Is there some documentation about it ?