### PR TITLE
ghdl backend: include and run instead of analyze and elab-run

### DIFF
--- a/tests/test_ghdl/Makefile
+++ b/tests/test_ghdl/Makefile
@@ -4,18 +4,22 @@ TOPLEVEL = top_module
 ANALYZE_OPTIONS = some analyze_options -P./libx
 RUN_OPTIONS = a few run_options
 
-all: analyze
+VHDL_SOURCES =  vhdl_file.vhd vhdl_lfile vhdl2008_file
 
-run:
-	ghdl --elab-run $(ANALYZE_OPTIONS) $(STD) $(TOPLEVEL) $(RUN_OPTIONS) $(EXTRA_OPTIONS)
+all: work-obj08.cf
+
+run: $(TOPLEVEL)
+	ghdl -r $(TOPLEVEL) $(RUN_OPTIONS) $(EXTRA_OPTIONS)
+
+$(TOPLEVEL): $(VHDL_SOURCES) work-obj08.cf
+	ghdl -m $(STD) $(ANALYZE_OPTIONS) $(TOPLEVEL)
 
 make_libraries_directories:
 	echo "Creating libraries directories"
 	mkdir -p libx
 
-
-analyze: make_libraries_directories
-	ghdl -a $(STD) $(ANALYZE_OPTIONS)  vhdl_file.vhd
-	ghdl -a $(STD) $(ANALYZE_OPTIONS) --work=libx  --workdir=./libx vhdl_lfile
-	ghdl -a $(STD) $(ANALYZE_OPTIONS)  vhdl2008_file
+work-obj08.cf:
+	ghdl -i $(STD) $(ANALYZE_OPTIONS)  vhdl_file.vhd
+	ghdl -i $(STD) $(ANALYZE_OPTIONS) --work=libx  --workdir=./libx vhdl_lfile
+	ghdl -i $(STD) $(ANALYZE_OPTIONS)  vhdl2008_file
 

--- a/tests/test_ghdl/analyze.cmd
+++ b/tests/test_ghdl/analyze.cmd
@@ -1,3 +1,3 @@
--a --std=08 some analyze_options -P./libx vhdl_file.vhd
--a --std=08 some analyze_options -P./libx --work=libx --workdir=./libx vhdl_lfile
--a --std=08 some analyze_options -P./libx vhdl2008_file
+ghdl -i --std=08 some analyze_options -P./libx  vhdl_file.vhd
+ghdl -i --std=08 some analyze_options -P./libx --work=libx  --workdir=./libx vhdl_lfile
+ghdl -i --std=08 some analyze_options -P./libx  vhdl2008_file

--- a/tests/test_ghdl/elab-run.cmd
+++ b/tests/test_ghdl/elab-run.cmd
@@ -1,1 +1,1 @@
---elab-run some analyze_options -P./libx --std=08 top_module a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello
+-r top_module a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello


### PR DESCRIPTION
Concerning this [fusesoc issue](https://github.com/olofk/fusesoc/issues/356) this commit replaces the analyze and elab-run strategy by the include and compile mentioned in there. This makes the order of rtl sources in core file irrelevant.