### PR TITLE
Allow severity ERROR and FAILURE to propagate error codes from ModelSim

### DIFF
--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -38,7 +38,7 @@ EXTRA_OPTIONS ?= $(VSIM_OPTIONS) $(addprefix -g,$(PARAMETERS)) $(addprefix +,$(P
 all: work $(VPI_MODULES)
 
 run: work $(VPI_MODULES)
-	$(VSIM) -do "run -all; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
+	$(VSIM) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
 
 run-gui: work $(VPI_MODULES)
 	$(VSIM) -gui $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)

--- a/tests/test_modelsim/Makefile
+++ b/tests/test_modelsim/Makefile
@@ -31,7 +31,7 @@ EXTRA_OPTIONS ?= $(VSIM_OPTIONS) $(addprefix -g,$(PARAMETERS)) $(addprefix +,$(P
 all: work $(VPI_MODULES)
 
 run: work $(VPI_MODULES)
-	$(VSIM) -do "run -all; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
+	$(VSIM) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
 
 run-gui: work $(VPI_MODULES)
 	$(VSIM) -gui $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)


### PR DESCRIPTION
As discussed in issue #107, ModelSim doesn't propagate error/failure information up to the shell. This makes integration with CI quite difficult. Based on a suggestion in that issue ticket, I've added some code that can check for the use of severity FAILURE or ERROR messages and pass that up to the shell as an exit code. Using NOTE or WARNING does not trigger an exit code change.

The change calls the coverage function twice as I was having real issues trying to store the returned value in a variable (using set, variable or global never seemed to work). If anyone has a suggestion, that'd be great.