### PR TITLE
Make Vivado exit with a non-zero exit status if synthesis fails.

### DIFF
--- a/edalize/templates/vivado/vivado-synth.tcl.j2
+++ b/edalize/templates/vivado/vivado-synth.tcl.j2
@@ -1,2 +1,3 @@
 launch_runs synth_1
 wait_on_run synth_1
+exit [regexp -nocase -- {synth_design (error|failed)} [get_property STATUS [get_runs synth_1]] match]


### PR DESCRIPTION
I found this article on a Xilinx forum:
[https://forums.xilinx.com/t5/Vivado-TCL-Community/Using-to-TCL-to-determine-if-synthesis-completed-ok-or/td-p/536155](https://forums.xilinx.com/t5/Vivado-TCL-Community/Using-to-TCL-to-determine-if-synthesis-completed-ok-or/td-p/536155)

It describes how you can query the status of a synthesis run. I've used this to influence the exit status value from a Vivado synthesis run, which is passed by Make to FuseSoC.

Please let me know if you agree/disagree with this propagation of exit values. I think this makes it more consistent with other tools.

I've run `pytest` and all tests pass.

#121 