### PR TITLE
Correct vvp wave dump argument position and change from LXT2 to FST

### DIFF
--- a/edalize/icarus.py
+++ b/edalize/icarus.py
@@ -16,7 +16,7 @@ $(TARGET):
 	iverilog -s$(TOPLEVEL) -c $(TARGET).scr -o $@ $(IVERILOG_OPTIONS)
 
 run: $(VPI_MODULES) $(TARGET)
-	vvp -n -M. -l icarus.log -lxt2 $(patsubst %.vpi,-m%,$(VPI_MODULES)) $(TARGET) $(EXTRA_OPTIONS)
+	vvp -n -M. -l icarus.log $(patsubst %.vpi,-m%,$(VPI_MODULES)) $(TARGET) -fst $(EXTRA_OPTIONS)
 
 clean:
 	$(RM) $(VPI_MODULES) $(TARGET)


### PR DESCRIPTION
When the -lxt2 argument is before the input file it is interpreted as
using the file "xt2" as a log file. The correct position is after the
input file. Also change the format from LXT2 to the newer FST.