### PR TITLE
Fix string parameter passing for verilator

### DIFF
--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -124,7 +124,7 @@ class Verilator(Edatool):
             f.write('--exe\n')
             f.write('\n'.join(opt_c_files))
             f.write('\n')
-            f.write(''.join(['-G{}={}\n'.format(key, self._param_value_str(value)) for key, value in self.vlogparam.items()]))
+            f.write(''.join(['-G{}={}\n'.format(key, self._param_value_str(value, str_quote_style='\\"')) for key, value in self.vlogparam.items()]))
             f.write(''.join(['-D{}={}\n'.format(key, self._param_value_str(value)) for key, value in self.vlogdefine.items()]))
 
         with open(os.path.join(self.work_root, 'Makefile'), 'w') as makefile:

--- a/tests/test_verilator/cc/mor1kx-generic_0.vc
+++ b/tests/test_verilator/cc/mor1kx-generic_0.vc
@@ -85,7 +85,7 @@
 ../../../cores/mor1kx-generic/bench/verilator/tb.cpp
 -Gvlogparam_bool=1
 -Gvlogparam_int=42
--Gvlogparam_str=hello
+-Gvlogparam_str=\"hello\"
 -Dvlogdefine_bool=1
 -Dvlogdefine_int=42
 -Dvlogdefine_str=hello


### PR DESCRIPTION
Strings parameters must be quoted in the .vc, otherwise you get errors
of the form:

'Illegal character in decimal constant:'