### PR TITLE
Deepcopy environment when it is to be restored later

### DIFF
--- a/tests/test_modelsim.py
+++ b/tests/test_modelsim.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 def test_modelsim():
     import os
@@ -25,7 +26,7 @@ def test_modelsim():
         'edalize_main.tcl',
     ])
 
-    orig_env = os.environ.copy()
+    orig_env = copy.deepcopy(os.environ)
     os.environ['MODEL_TECH'] = os.path.join(tests_dir, 'mock_commands')
 
     backend.build()

--- a/tests/test_rivierapro.py
+++ b/tests/test_rivierapro.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 
 def test_rivierapro():
     import os
@@ -24,7 +25,7 @@ def test_rivierapro():
         'edalize_main.tcl',
     ])
 
-    orig_env = os.environ.copy()
+    orig_env = copy.deepcopy(os.environ)
     os.environ['ALDEC_PATH'] = os.path.join(tests_dir, 'mock_commands')
 
     backend.build()


### PR DESCRIPTION
This is my first PR, so I hope I'm doing it correctly...

The change is a small one that has caused me trouble when developing my Cocotb backend (appearing up here soon!). By not using a deep copy when copying `os.environ`, the actual environment is not updated on subsequent tests. This didn't cause a problem before because ModelSim was the only test relying on that functionality. RivieraPro appears to do so, but the only use of the modified environment is within the Python - not by a subprocess. The upshot is that when I added my cocotb test, it broke the ModelSim one because it ran first.

Here is a pytest file that demonstrates the problem:

```
import pytest
import os
import subprocess

def run_test(test_value):
    orig_env = os.environ.copy()
    os.environ['TEST_VAR'] = test_value
    result = subprocess.check_output('echo -n ${TEST_VAR}', shell=True).decode('ascii')
    assert result == test_value
    os.environ = orig_env

def test_copy_env_a():
    run_test('value a')

def test_copy_env_b():
    run_test('value b')
```

And another that shows the fix:

```
import pytest
import copy
import os
import subprocess

def run_test(test_value):
    orig_env = copy.deepcopy(os.environ)
    os.environ['TEST_VAR'] = test_value
    result = subprocess.check_output('echo -n ${TEST_VAR}', shell=True).decode('ascii')
    assert result == test_value
    os.environ = orig_env

def test_copy_env_a():
    run_test('value a')

def test_copy_env_b():
    run_test('value b')
```