### PR TITLE
Solved open_hw deprecation in Vivado 2019.2

### DIFF
--- a/edalize/templates/vivado/vivado-program.tcl.j2
+++ b/edalize/templates/vivado/vivado-program.tcl.j2
@@ -24,7 +24,7 @@ if { $explicit_hw_target != "" } {
 }
 
 # Connect to Xilinx Hardware Server
-open_hw
+if { [ catch { open_hw_manager } ] } { open_hw }
 connect_hw_server
 
 if { $explicit_hw_target == "" } {

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_pgm.tcl
@@ -24,7 +24,7 @@ if { $explicit_hw_target != "" } {
 }
 
 # Connect to Xilinx Hardware Server
-open_hw
+if { [ catch { open_hw_manager } ] } { open_hw }
 connect_hw_server
 
 if { $explicit_hw_target == "" } {

--- a/tests/test_vivado/test_vivado_0_pgm.tcl
+++ b/tests/test_vivado/test_vivado_0_pgm.tcl
@@ -24,7 +24,7 @@ if { $explicit_hw_target != "" } {
 }
 
 # Connect to Xilinx Hardware Server
-open_hw
+if { [ catch { open_hw_manager } ] } { open_hw }
 connect_hw_server
 
 if { $explicit_hw_target == "" } {


### PR DESCRIPTION
Vivado 2019.2 complains during programming:
```
WARNING: 'open_hw' is deprecated, please use 'open_hw_manager' instead.
```
This patch allows using previous and future versions which support `open_hw` or `open_hw_manager`.

The pytest fails due to what I reported on #132.