### PR TITLE
Relax pinning of Jinja2 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,10 @@ setup(
     ],
     install_requires=[
         'pytest>=3.3.0',
-        # Avoid Jinja 2.11 until https://github.com/pallets/jinja/issues/1138
-        # is sorted.
-        'Jinja2 >=2.8, <2.11',
+        # 2.11.0 and .1 introduced an incompatible change in template output,
+        # which was fixed in 2.11.2 and later.
+        # https://github.com/pallets/jinja/issues/1138
+        'Jinja2 >=2.8, !=2.11.0, !=2.11.1',
     ],
     tests_require=[
         'vunit_hdl>=4.0.8'


### PR DESCRIPTION
Jinja 2.11.2 fixed https://github.com/pallets/jinja/issues/1138 which
prevented us from using the 2.11 line, we therefore can relax the version
constraint.