### PR TITLE
Add GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      # You can use PyPy versions in python-version. For example, pypy2 and pypy3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+    - name: Install Tox and any other packages
+      run: pip install tox
+    - name: Build package and run tests with tox
+      run: tox -e py

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Edalize
 =======
 
+.. image:: https://github.com/olofk/edalize/workflows/CI/badge.svg
+        :target: https://github.com/olofk/edalize/workflows/CI/badge.svg
+        :alt: CI status
+
 .. image:: https://readthedocs.org/projects/edalize/badge/?version=latest
         :target: https://edalize.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,10 @@ setup(
     ],
     install_requires=[
         'pytest>=3.3.0',
-        # Avoid Jinja 2.11 until https://github.com/pallets/jinja/issues/1138
-        # is sorted.
-        'Jinja2 >=2.8, <2.11',
+        # 2.11.0 and .1 introduced an incompatible change in template output,
+        # which was fixed in 2.11.2 and later.
+        # https://github.com/pallets/jinja/issues/1138
+        'Jinja2 >=2.8, !=2.11.0, !=2.11.1',
     ],
     tests_require=[
         'vunit_hdl>=4.0.8'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py2,py3
+
+[testenv]
+deps = pytest
+commands = pytest {posargs}


### PR DESCRIPTION
A simple CI setup which runs pytest in tox to also test the packaging of
edalize, catching common errors such as forgetting to add templates in
the manifest files.