### PR TITLE
[veriblelint] Add option to include config file via source files

### DIFF
--- a/edalize/veriblelint.py
+++ b/edalize/veriblelint.py
@@ -19,9 +19,6 @@ class Veriblelint(Edatool):
                          {'name': 'ruleset',
                           'type': 'String',
                           'desc': 'Ruleset: [default|all|none]'},
-                         {'name': 'rules_config_file',
-                          'type': 'String',
-                          'desc': 'Path to the rule config file'}
                     ],
                     'lists': [
                          {'name' : 'verible_lint_args',
@@ -39,8 +36,6 @@ class Veriblelint(Edatool):
     def _get_tool_args(self):
         args = [ '--lint_fatal', '--parse_fatal' ]
 
-        if 'rules_config_file' in self.tool_options:
-            args.append('--rules_config=' + ','.join(self.tool_options['rules_config_file']))
         if 'rules' in self.tool_options:
             args.append('--rules=' + ','.join(self.tool_options['rules']))
         if 'ruleset' in self.tool_options:
@@ -54,19 +49,28 @@ class Veriblelint(Edatool):
         (src_files, incdirs) = self._get_fileset_files(force_slash=True)
 
         src_files_filtered = []
+        config_files_filtered = []
         for src_file in src_files:
             ft = src_file.file_type
-            if not ft.startswith("verilogSource") and not ft.startswith("systemVerilogSource"):
-                continue
-            src_files_filtered.append(src_file.name)
+
+            if ft.startswith("verilogSource") or ft.startswith("systemVerilogSource"):
+               src_files_filtered.append(src_file.name)
+            elif ft.startswith("veribleLintRules"):
+               config_files_filtered.append(src_file.name)
 
         if len(src_files_filtered) == 0:
             logger.warning("No SystemVerilog source files to be processed.")
             return
 
         lint_fail = False
+        args = self._get_tool_args()
+        if len(config_files_filtered) > 1:
+            raise RuntimeError("Too many Verible lint rule files specified")
+        elif len(config_files_filtered) == 1:
+            args.append('--rules_config=' + config_files_filtered[0])
+
         for src_file in src_files_filtered:
-            cmd = ['verilog_lint'] + self._get_tool_args() + [src_file]
+            cmd = ['verilog_lint'] + args + [src_file]
             logger.debug("Running " + ' '.join(cmd))
 
             try:

--- a/tests/edalize_common.py
+++ b/tests/edalize_common.py
@@ -127,6 +127,7 @@ FILES = [
     {'name' : 'cpp_file.cpp' , 'file_type' : 'cppSource'},
     {'name' : 'c_header.h'   , 'file_type' : 'cSource', 'is_include_file' : True},
     {'name' : 'c_header.h'   , 'file_type' : 'cppSource', 'is_include_file' : True},
+    {'name' : 'config.vbl'   , 'file_type' : 'veribleLintRules'}
 ]
 """Files of all supported file types."""
 

--- a/tests/test_veriblelint/lint/verilog_lint.cmd
+++ b/tests/test_veriblelint/lint/verilog_lint.cmd
@@ -1,3 +1,3 @@
---lint_fatal --parse_fatal sv_file.sv
---lint_fatal --parse_fatal vlog_file.v
---lint_fatal --parse_fatal vlog05_file.v
+--lint_fatal --parse_fatal --rules_config=config.vbl sv_file.sv
+--lint_fatal --parse_fatal --rules_config=config.vbl vlog_file.v
+--lint_fatal --parse_fatal --rules_config=config.vbl vlog05_file.v

--- a/tests/test_vivado/test_vivado_0.tcl
+++ b/tests/test_vivado/test_vivado_0.tcl
@@ -26,6 +26,7 @@ read_xdc xdc_file.xdc
 read_mem bootrom.mem
 add_files -norecurse c_file.c
 add_files -norecurse cpp_file.cpp
+add_files -norecurse config.vbl
 
 set_property include_dirs [list . .] [get_filesets sources_1]
 set_property top top_module [current_fileset]


### PR DESCRIPTION
This adds support for specifying the `veriblelint` configuration file as part of the design sources, similarly to the `ascentlint` target. This makes it possible to create a common core file that other core files can depend on. Otherwise, we would have to hardcode the path to the config file in each core file with a lint target, which is a bit brittle and cumbersome to maintain.

This implementation throws an error if more than one file of type `veribleLintConfig` is discovered in the sources. Further, if the `rules_config_file` option is specified in a core file, that option will override the config file discovered as part of the sources, and a WARNING will be printed that this has occurred.

Signed-off-by: Michael Schaffner <msf@google.com>