### PR TITLE
templates: yosys-makefile.j2: add missing edif file in clean rule

### DIFF
--- a/edalize/templates/yosys/yosys-makefile.j2
+++ b/edalize/templates/yosys/yosys-makefile.j2
@@ -13,4 +13,4 @@ all: $(TARGET).{{ default_target }}
 	yosys -l yosys.log -p "tcl $?"
 
 clean:
-	rm -f $(TARGET).blif $(TARGET).json
+	rm -f $(TARGET).blif $(TARGET).json $(TARGET).edif

--- a/tests/test_vivado/yosys/test_vivado_yosys_0.mk
+++ b/tests/test_vivado/yosys/test_vivado_yosys_0.mk
@@ -13,4 +13,4 @@ all: $(TARGET).edif
 	yosys -l yosys.log -p "tcl $?"
 
 clean:
-	rm -f $(TARGET).blif $(TARGET).json
+	rm -f $(TARGET).blif $(TARGET).json $(TARGET).edif


### PR DESCRIPTION
Since 2fce13111de2e7d071d2ddd08598fae5d4fe6a68#diff-3906f3cf8d9b1bb7335f0c02908fd07a a new target is added to generate .edif file. But the clean rule has not beeing updated accordinly.