### PR TITLE
Vivado: fix Yosys options passing

### DIFF
--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -98,7 +98,7 @@ class Vivado(Edatool):
                     'tool_options'  : {'yosys' : {
                                             'arch' : 'xilinx',
                                             'output_format' : 'edif',
-                                            'synth_options' : yosys_synth_options,
+                                            'yosys_synth_options' : yosys_synth_options,
                                             'yosys_as_subtool' : True,
                                             'script_name'   : 'yosys.tcl',
                                             }


### PR DESCRIPTION
This PR fixes a bug where synth options were not passed to Yosys in Yosys -> Vivado flow.