### PR TITLE
Allow verbose output from nextpnr

### DIFF
--- a/edalize/templates/icestorm/icestorm-makefile.j2
+++ b/edalize/templates/icestorm/icestorm-makefile.j2
@@ -20,7 +20,7 @@ stats: $(TARGET).stat
 %.json: %.mk
 	$(MAKE) -f $<
 %_next.asc: %.json
-	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
+	nextpnr-ice40 -l next.log $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
 %.tim: %_$(PNR).asc
@@ -29,7 +29,7 @@ stats: $(TARGET).stat
 	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
-	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
+	nextpnr-ice40 $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
 
 clean:
 	rm -f $(TARGET).blif $(TARGET).json $(TARGET)_arachne.asc $(TARGET)_next.asc $(TARGET).bin

--- a/edalize/templates/trellis/trellis-makefile.j2
+++ b/edalize/templates/trellis/trellis-makefile.j2
@@ -9,12 +9,12 @@ all: $(TARGET).bit
 %.json: %.mk
 	$(MAKE) -f $<
 %.config: %.json
-	nextpnr-ecp5 -l next.log -q $(NEXTPNR_OPTIONS) --lpf $(LPF_FILE) --json $? --textcfg $@
+	nextpnr-ecp5 -l next.log $(NEXTPNR_OPTIONS) --lpf $(LPF_FILE) --json $? --textcfg $@
 %.bit: %.config
 	ecppack $< $@
 
 build-gui: $(TARGET).json
-	nextpnr-ecp5 -q $(NEXTPNR_OPTIONS) --json $? --textcfg $@ --gui
+	nextpnr-ecp5 $(NEXTPNR_OPTIONS) --json $? --textcfg $@ --gui
 
 clean:
 	rm -f  $(TARGET).json $(TARGET).config $(TARGET).bit

--- a/tests/test_icestorm/Makefile
+++ b/tests/test_icestorm/Makefile
@@ -4,7 +4,7 @@ TARGET   := test_icestorm_0
 PCF_FILE := pcf_file.pcf
 PNR      ?= arachne
 ARACHNE_PNR_OPTIONS := a few arachne_pnr_options
-NEXTPNR_OPTIONS     := 
+NEXTPNR_OPTIONS     :=
 DEVICE   := None
 
 all: $(TARGET).bin
@@ -20,7 +20,7 @@ stats: $(TARGET).stat
 %.json: %.mk
 	$(MAKE) -f $<
 %_next.asc: %.json
-	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
+	nextpnr-ice40 -l next.log $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
 %.tim: %_$(PNR).asc
@@ -29,7 +29,7 @@ stats: $(TARGET).stat
 	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
-	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
+	nextpnr-ice40 $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
 
 clean:
 	rm -f $(TARGET).blif $(TARGET).json $(TARGET)_arachne.asc $(TARGET)_next.asc $(TARGET).bin

--- a/tests/test_icestorm/nextpnr/Makefile
+++ b/tests/test_icestorm/nextpnr/Makefile
@@ -20,7 +20,7 @@ stats: $(TARGET).stat
 %.json: %.mk
 	$(MAKE) -f $<
 %_next.asc: %.json
-	nextpnr-ice40 -l next.log -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
+	nextpnr-ice40 -l next.log $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@
 %.bin: %_$(PNR).asc
 	icepack $< $@
 %.tim: %_$(PNR).asc
@@ -29,7 +29,7 @@ stats: $(TARGET).stat
 	icebox_stat $< > $@
 
 build-gui: $(TARGET).json
-	nextpnr-ice40 -q $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
+	nextpnr-ice40 $(NEXTPNR_OPTIONS) --pcf $(PCF_FILE) --json $? --asc $@ --gui
 
 clean:
 	rm -f $(TARGET).blif $(TARGET).json $(TARGET)_arachne.asc $(TARGET)_next.asc $(TARGET).bin


### PR DESCRIPTION
Allow verbose output from edalize for nextpnr-ice40 and nextpnr-ecp5 by removing the quiet flag (-q)

Users may add the flag upstream via NEXTPNR_OPTIONS
For example, this can be done in the Fusesoc frontend by using nextpnr_options on the respective toolchain:

https://fusesoc.readthedocs.io/en/master/ref/capi2.html#icestorm
https://fusesoc.readthedocs.io/en/master/ref/capi2.html#trellis

Closes #168 