### PR TITLE
Correct #! lines for xcelium tests

### DIFF
--- a/tests/mock_commands/xcelium/tools/bin/xrun
+++ b/tests/mock_commands/xcelium/tools/bin/xrun
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import shlex
 

--- a/tests/mock_commands/xcelium/xmroot
+++ b/tests/mock_commands/xcelium/xmroot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import pathlib
 
 print(pathlib.Path(__file__).resolve().parent)


### PR DESCRIPTION
These fail on at least my machine (Debian unstable) because "python"
is Python 2.7, rather than Python 3.x.