### PR TITLE
Use pytest fixtures to avoid boilerplate in tests

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -14,8 +14,8 @@ Mocks for commands
 ------------------
 
 We provide mocks (stand-ins) for all tools that we want to exercise in tests (located in :file:`tests/mock_commands/`).
-These mocks are very simplified "models" of the actual tool, and are called instead of the actual tool
-(the :func:`edalize_common.setup_backend` and :func:`edalize_common.setup_backend` functions prepend them to :envvar:`PATH`).
+These mocks are very simplified "models" of the actual tool, and are called instead of the actual tool.
+They are prepended to :envvar:`PATH` by the setup code in the :func:`edalize_common.make_edalize_test` pytest fixture.
 
 In the easiest case, these mocks just write out the commandline they were called with (into a file :file:`<tool>.cmd`).
 
@@ -28,14 +28,14 @@ In a more complex test setup (e.g. for ``vcs``),
 Testcases
 ---------
 
-A testcase (being run with :command:`pytest`) is usually calling the tool to be tested via :func:`edalize_common.setup_backend`.
-Instead of the actual tool, the tool mock is used.
+To define a testcase, use the :func:`edalize_common.make_edalize_test` pytest factory fixture.
+This defines a factory that you can call to set up a mocked-up backend appropriately.
+See the documentation for :py:class:`edalize_common.TestFixture` for details of the supported keywords.
 
-The output of the tool mock is compared (using :func:`edalize_common.compare_files`)
-with the reference files in :file:`tests/test_<tool>/<testcase>/*`.
+The :py:attr:`backend` attribute of the returned fixture has :py:meth:`configure`, :py:meth:`build` and :py:meth:`run` methods.
+The testcase should call these in order, setting up files as necessary between calls and checking whether the results match by calling the fixture's :py:meth:`compare_files` method.
 
-If the environment variable :envvar:`GOLDEN_RUN` is set,
-the generated files are copied to become the new reference files in this step.
+If the environment variable :envvar:`GOLDEN_RUN` is set, the :py:meth:`compare_files` method copies the generated files are copied to become the new reference files, rather than checking their contents.
 
 
 Helper Module

--- a/tests/test_ascentlint.py
+++ b/tests/test_ascentlint.py
@@ -1,29 +1,17 @@
-import pytest
+from edalize_common import make_edalize_test
 
 
-def test_ascentlint_defaults():
+def test_ascentlint_defaults(make_edalize_test):
     """ Test the default configuration of Ascent Lint """
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
+    tf = make_edalize_test('ascentlint',
+                           test_name='test_ascentlint',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           ref_dir='defaults')
 
-    ref_dir = os.path.join(tests_dir, __name__, 'defaults')
-    paramtypes = ['vlogdefine', 'vlogparam']
-    name = 'test_ascentlint'
-    tool = 'ascentlint'
-    tool_options = {}
+    tf.backend.configure()
 
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options)
-    backend.configure()
+    tf.compare_files(['Makefile', 'run-ascentlint.tcl', 'sources.f'])
 
-    compare_files(ref_dir, work_root, [
-        'Makefile',
-        'run-ascentlint.tcl',
-        'sources.f',
-    ])
+    tf.backend.build()
 
-    backend.build()
-    compare_files(ref_dir, work_root, [
-        'ascentlint.cmd',
-    ])
+    tf.compare_files(['ascentlint.cmd'])

--- a/tests/test_diamond.py
+++ b/tests/test_diamond.py
@@ -1,35 +1,26 @@
-import pytest
+from edalize_common import make_edalize_test
 
-def test_diamond():
+
+def test_diamond(make_edalize_test):
+    name = 'test_diamond_0'
+    tf = make_edalize_test('diamond',
+                           test_name=name,
+                           param_types=['generic', 'vlogdefine', 'vlogparam'],
+                           tool_options={
+                               'part': 'LFE5U-85F-6BG381C',
+                           })
+
+    tf.backend.configure()
+
+    tf.compare_files([name + '.tcl', name + '_run.tcl'])
+
+    tf.backend.build()
+
+    tf.compare_files(['diamondc.cmd'])
+
+
+def test_diamond_minimal(tmpdir):
     import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['generic', 'vlogdefine', 'vlogparam']
-    tool         = 'diamond'
-    name         = 'test_{}_0'.format(tool)
-    tool_options = {
-        'part' : 'LFE5U-85F-6BG381C',
-    }
-
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
-
-    compare_files(ref_dir, work_root, [
-        name+'.tcl',
-        name+'_run.tcl',
-    ])
-
-    backend.build()
-    compare_files(ref_dir, work_root, [
-        'diamondc.cmd',
-    ])
-
-def test_diamond_minimal():
-    import os
-    import shutil
-    import tempfile
 
     from edalize import get_edatool
 
@@ -42,7 +33,7 @@ def test_diamond_minimal():
         'part' : 'LFE5U-85F-6BG381C',
     }
     name = 'test_{}_minimal_0'.format(tool)
-    work_root = tempfile.mkdtemp(prefix=tool+'_')
+    work_root = str(tmpdir)
 
     edam = {'name'         : name,
             'tool_options' : {tool : tool_options}

--- a/tests/test_edam.py
+++ b/tests/test_edam.py
@@ -1,5 +1,5 @@
 import pytest
-import shutil
+
 
 def test_empty_edam():
     import tempfile
@@ -79,9 +79,8 @@ def test_verilog_include_file_with_partial_include_path():
     assert len(parsed_files) == 0
     assert incdirs == ['../some_dir']
 
-def test_edam_hooks():
+def test_edam_hooks(tmpdir):
     import os.path
-    import tempfile
     from edalize import get_edatool
 
     tests_dir = os.path.dirname(__file__)
@@ -92,7 +91,7 @@ def test_edam_hooks():
         {'cmd' : ['sh', os.path.join(ref_dir, script)],
          'name' : script}]}
 
-    work_root = tempfile.mkdtemp(prefix='edam_hooks_')
+    work_root = str(tmpdir)
     edam = {'hooks' : hooks,
                'name' : script}
 

--- a/tests/test_ghdl.py
+++ b/tests/test_ghdl.py
@@ -1,28 +1,25 @@
-import pytest
+import os
+from edalize_common import make_edalize_test
 
-def test_ghdl():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['generic']
-    name         = 'test_ghdl'
-    tool         = 'ghdl'
-    tool_options = {'analyze_options' : ['some', 'analyze_options'],
-                    'run_options'     : ['a', 'few', 'run_options']}
+def test_ghdl(make_edalize_test):
+    tf = make_edalize_test('ghdl',
+                           param_types=['generic'],
+                           tool_options={
+                               'analyze_options': ['some', 'analyze_options'],
+                               'run_options': ['a', 'few', 'run_options']
+                           })
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
     for vhdl_file in ['vhdl_file.vhd', 'vhdl_lfile',  'vhdl2008_file']:
-        with open(os.path.join(work_root, vhdl_file), 'a'):
-            os.utime(os.path.join(work_root, vhdl_file), None)
+        with open(os.path.join(tf.work_root, vhdl_file), 'a'):
+            os.utime(os.path.join(tf.work_root, vhdl_file), None)
 
-    backend.configure()
+    tf.backend.configure()
 
-    compare_files(ref_dir, work_root, ['Makefile'])
+    tf.compare_files(['Makefile'])
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['analyze.cmd'])
+    tf.backend.build()
+    tf.compare_files(['analyze.cmd'])
 
-    backend.run()
-    compare_files(ref_dir, work_root, ['elab-run.cmd'])
+    tf.backend.run()
+    tf.compare_files(['elab-run.cmd'])

--- a/tests/test_icarus.py
+++ b/tests/test_icarus.py
@@ -1,39 +1,31 @@
-import pytest
+from edalize_common import make_edalize_test
 
-def test_icarus():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam']
-    name         = 'test_icarus_0'
-    tool         = 'icarus'
+def test_icarus(make_edalize_test):
+    name = 'test_icarus_0'
     tool_options = {
-        'iverilog_options' : ['some', 'iverilog_options'],
-        'timescale'        : '1ns/1ns',
+        'iverilog_options': ['some', 'iverilog_options'],
+        'timescale': '1ns/1ns',
     }
+    tf = make_edalize_test('icarus',
+                           test_name=name,
+                           tool_options=tool_options,
+                           use_vpi=True)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options, use_vpi=True)
-    backend.configure()
+    tf.backend.configure()
 
-    compare_files(ref_dir, work_root, ['Makefile',
-                                       name+'.scr',
-                                       'timescale.v',
-    ])
+    tf.compare_files(['Makefile', name + '.scr', 'timescale.v'])
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['iverilog.cmd'])
-    compare_files(ref_dir, work_root, ['iverilog-vpi.cmd'])
+    tf.backend.build()
+    tf.compare_files(['iverilog.cmd', 'iverilog-vpi.cmd'])
 
-    backend.run()
+    tf.backend.run()
 
-    compare_files(ref_dir, work_root, ['vvp.cmd'])
+    tf.compare_files(['vvp.cmd'])
 
-def test_icarus_minimal():
+
+def test_icarus_minimal(tmpdir):
     import os
-    import shutil
-    import tempfile
 
     from edalize import get_edatool
 
@@ -43,7 +35,7 @@ def test_icarus_minimal():
     os.environ['PATH'] = os.path.join(tests_dir, 'mock_commands')+':'+os.environ['PATH']
     tool = 'icarus'
     name = 'test_'+tool+'_minimal_0'
-    work_root = tempfile.mkdtemp(prefix=tool+'_')
+    work_root = str(tmpdir)
 
     edam = {'name'         : name,
                'toplevel' : 'top'}

--- a/tests/test_icestorm.py
+++ b/tests/test_icestorm.py
@@ -1,129 +1,87 @@
+import os
 import pytest
+from edalize_common import make_edalize_test
 
-def test_icestorm():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
+def run_icestorm_test(tf, pnr_cmdfile='arachne-pnr.cmd'):
+    tf.backend.configure()
+
+    tf.compare_files(['Makefile', tf.test_name + '.tcl'])
+
+    f = os.path.join(tf.work_root, 'pcf_file.pcf')
+    with open(f, 'a'):
+        os.utime(f, None)
+
+    tf.backend.build()
+    tf.compare_files(['yosys.cmd', pnr_cmdfile, 'icepack.cmd'])
+
+
+def test_icestorm(make_edalize_test):
     tool_options = {
-        'yosys_synth_options' : ['some', 'yosys_synth_options'],
-        'arachne_pnr_options' : ['a', 'few', 'arachne_pnr_options'],
+        'yosys_synth_options': ['some', 'yosys_synth_options'],
+        'arachne_pnr_options': ['a', 'few', 'arachne_pnr_options']
     }
+    tf = make_edalize_test('icestorm',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           tool_options=tool_options)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
+    run_icestorm_test(tf)
 
-    compare_files(ref_dir, work_root, ['Makefile',
-                                       name+'.tcl'])
 
-    f = os.path.join(work_root, 'pcf_file.pcf')
-    with open(f, 'a'):
-        os.utime(f, None)
+def test_icestorm_minimal(make_edalize_test):
+    files = [{'name': 'pcf_file.pcf', 'file_type': 'PCF'}]
+    tf = make_edalize_test('icestorm',
+                           param_types=[],
+                           files=files,
+                           ref_dir='minimal')
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['yosys.cmd'])
-    compare_files(ref_dir, work_root, ['arachne-pnr.cmd'])
-    compare_files(ref_dir, work_root, ['icepack.cmd'])
+    run_icestorm_test(tf)
 
-def test_icestorm_minimal():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend_minimal, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__, 'minimal')
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
+def test_icestorm_no_pcf(make_edalize_test):
+    tf = make_edalize_test('icestorm',
+                           param_types=[],
+                           files=[])
 
-    (backend, work_root) = setup_backend_minimal(name, tool, [{'name' : 'pcf_file.pcf', 'file_type' : 'PCF'}])
-    backend.configure()
+    tf.backend.configure()
+    assert os.path.exists(os.path.join(tf.work_root, 'empty.pcf'))
 
-    compare_files(ref_dir, work_root, ['Makefile',
-                                       name+'.tcl'])
 
-    f = os.path.join(work_root, 'pcf_file.pcf')
-    with open(f, 'a'):
-        os.utime(f, None)
+def test_icestorm_multiple_pcf(make_edalize_test):
+    files = [{'name': 'pcf_file.pcf', 'file_type': 'PCF'},
+             {'name': 'pcf_file2.pcf', 'file_type': 'PCF'}]
+    tf = make_edalize_test('icestorm',
+                           param_types=[],
+                           files=files)
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['yosys.cmd'])
-    compare_files(ref_dir, work_root, ['arachne-pnr.cmd'])
-    compare_files(ref_dir, work_root, ['icepack.cmd'])
-
-def test_icestorm_no_pcf():
-    import os
-
-    from edalize_common import compare_files, setup_backend_minimal, tests_dir
-
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
-
-    (backend, work_root) = setup_backend_minimal(name, tool, [])
-    backend.configure()
-    assert os.path.exists(os.path.join(work_root, 'empty.pcf'))
-
-def test_icestorm_multiple_pcf():
-    import os
-
-    from edalize_common import compare_files, setup_backend_minimal, tests_dir
-
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
-
-    (backend, work_root) = setup_backend_minimal(name, tool, [{'name' : 'pcf_file.pcf', 'file_type' : 'PCF'},
-                                                              {'name' : 'pcf_file2.pcf', 'file_type' : 'PCF'}])
     with pytest.raises(RuntimeError) as e:
-        backend.configure()
+        tf.backend.configure()
     assert "Icestorm backend supports only one PCF file. Found pcf_file.pcf, pcf_file2.pcf" in str(e.value)
 
-def test_icestorm_nextpnr():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__, 'nextpnr')
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
+def test_icestorm_nextpnr(make_edalize_test):
     tool_options = {
-        'yosys_synth_options' : ['some', 'yosys_synth_options'],
-        'arachne_pnr_options' : ['a', 'few', 'arachne_pnr_options'],
-        'nextpnr_options'     : ['multiple', 'nextpnr_options'],
-        'pnr'                 : 'next',
+        'yosys_synth_options': ['some', 'yosys_synth_options'],
+        'arachne_pnr_options': ['a', 'few', 'arachne_pnr_options'],
+        'nextpnr_options': ['multiple', 'nextpnr_options'],
+        'pnr': 'next'
     }
+    tf = make_edalize_test('icestorm',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           tool_options=tool_options,
+                           ref_dir='nextpnr')
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
+    run_icestorm_test(tf, pnr_cmdfile='nextpnr-ice40.cmd')
 
-    compare_files(ref_dir, work_root, ['Makefile',
-                                       name+'.tcl'])
 
-    f = os.path.join(work_root, 'pcf_file.pcf')
-    with open(f, 'a'):
-        os.utime(f, None)
+def test_icestorm_invalid_pnr(make_edalize_test):
+    name = 'test_icestorm_0'
+    tf = make_edalize_test('icestorm',
+                           test_name=name,
+                           param_types=['vlogdefine', 'vlogparam'],
+                           tool_options={'pnr': 'invalid'},
+                           ref_dir='nextpnr')
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['yosys.cmd'])
-    compare_files(ref_dir, work_root, ['nextpnr-ice40.cmd'])
-    compare_files(ref_dir, work_root, ['icepack.cmd'])
-
-def test_icestorm_invalid_pnr():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_icestorm_0'
-    tool         = 'icestorm'
-    tool_options = {
-        'pnr'                 : 'invalid',
-    }
-
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
     with pytest.raises(RuntimeError) as e:
-        backend.configure()
+        tf.backend.configure()
     assert "nvalid pnr option 'invalid'. Valid values are 'arachne' for Arachne-pnr or 'next' for nextpnr" in str(e.value)

--- a/tests/test_ise.py
+++ b/tests/test_ise.py
@@ -1,53 +1,39 @@
+from edalize_common import make_edalize_test
 import pytest
 
-def test_ise():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_ise_0'
-    tool         = 'ise'
+def test_ise(make_edalize_test):
+    name = 'test_ise_0'
     tool_options = {
-        'family'  : 'spartan6',
-        'device'  : 'xc6slx45',
-        'package' : 'csg324',
-        'speed'   : '-2'
+        'family': 'spartan6',
+        'device': 'xc6slx45',
+        'package': 'csg324',
+        'speed': '-2'
     }
+    tf = make_edalize_test('ise',
+                           test_name=name,
+                           param_types=['vlogdefine', 'vlogparam'],
+                           tool_options=tool_options)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
+    tf.backend.configure()
 
-    compare_files(ref_dir, work_root, ['Makefile',
-                                       'config.mk',
-                                       name+'.tcl',
-                                       name+'_run.tcl',
-    ])
+    tf.compare_files(['Makefile', 'config.mk',
+                      name + '.tcl', name + '_run.tcl'])
 
-    #f = os.path.join(work_root, 'pcf_file.pcf')
-    #with open(f, 'a'):
-    #    os.utime(f, None)
+    tf.backend.build()
+    tf.compare_files(['xtclsh.cmd'])
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['xtclsh.cmd'])
 
-def test_ise_missing_options():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_ise_0'
-    tool         = 'ise'
+def test_ise_missing_options(make_edalize_test):
     tool_options = {
-        'family'  : 'spartan6',
-        'device'  : 'xc6slx45',
-        'package' : 'csg324',
+        'family': 'spartan6',
+        'device': 'xc6slx45',
+        'package': 'csg324',
     }
+    tf = make_edalize_test('ise',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           tool_options=tool_options)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
     with pytest.raises(RuntimeError) as e:
-        backend.configure()
+        tf.backend.configure()
     assert "Missing required option 'speed'" in str(e.value)

--- a/tests/test_isim.py
+++ b/tests/test_isim.py
@@ -1,32 +1,23 @@
-import pytest
+from edalize_common import make_edalize_test
 
-def test_isim():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam']
-    name         = 'test_isim_0'
-    tool         = 'isim'
+def test_isim(make_edalize_test):
     tool_options = {
-        'fuse_options' : ['some', 'fuse_options'],
-        'isim_options' : ['a', 'few', 'isim_options'],
+        'fuse_options': ['some', 'fuse_options'],
+        'isim_options': ['a', 'few', 'isim_options'],
     }
+    tf = make_edalize_test('isim',
+                           tool_options=tool_options)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
+    tf.backend.configure()
 
-    compare_files(ref_dir, work_root,
-                  ['config.mk',
-                   'Makefile',
-                   'run_test_isim_0.tcl',
-                   'test_isim_0.prj'])
+    tf.compare_files(['config.mk',
+                      'Makefile',
+                      'run_test_isim_0.tcl',
+                      'test_isim_0.prj'])
 
-    dummy_exe = 'test_isim_0'
-    shutil.copy(os.path.join(ref_dir, dummy_exe),
-                os.path.join(work_root, dummy_exe))
+    tf.copy_to_work_root('test_isim_0')
 
-    backend.run()
+    tf.backend.run()
 
-    compare_files(ref_dir, work_root, ['run.cmd'])
+    tf.compare_files(['run.cmd'])

--- a/tests/test_quartus.py
+++ b/tests/test_quartus.py
@@ -1,4 +1,5 @@
-import pytest
+import os
+from edalize_common import make_edalize_test
 
 qsys_file = """<?xml version="1.0" encoding="UTF-8"?>
 <system name="test">
@@ -22,14 +23,7 @@ test_sets = {"Standard": {"Quartus": ['ip-generate.cmd', 'quartus_asm.cmd', 'qua
              "Pro"     : {"Quartus": ['qsys-generate.cmd', 'quartus_asm.cmd', 'quartus_fit.cmd', 'quartus_syn.cmd', 'quartus_sh.cmd', 'quartus_sta.cmd'],
                           "DSE"    : ['qsys-generate.cmd', 'quartus_syn.cmd', 'quartus_sh.cmd', 'quartus_dse.cmd']}}
 
-def test_quartus():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    paramtypes   = ['vlogdefine', 'vlogparam']
-    name         = 'test_quartus_0'
-    tool         = 'quartus'
+def test_quartus(make_edalize_test):
     tool_options = {
         'family'          : 'Cyclone V',
         'device'          : '5CSXFC6D6F31C8ES',
@@ -41,26 +35,27 @@ def test_quartus():
     for edition in ["Standard", "Pro"]:
         for pnr in ["Quartus", "DSE"]:
             # Each edition and P&R tool has its own set of representative files
-            ref_dir       = os.path.join(tests_dir, __name__, edition)
-
             if pnr == "DSE":
                 _tool_options = {**tool_options, "pnr": "dse"}
             else:
                 _tool_options = {**tool_options}
 
-            # Ensure we test the edition we intend to, even if quartus_sh is present
+            # Ensure we test the edition we intend to, even if quartus_sh is
+            # present
             os.environ["FUSESOC_QUARTUS_EDITION"] = edition
-            (backend, work_root) = setup_backend(paramtypes, name, tool, _tool_options)
 
-            # Each edition performs checks on the QSYS files present, so provide
-            # a minimal example
-            with open(os.path.join(work_root, "qsys_file"), 'w') as f:
+            tf = make_edalize_test('quartus',
+                                   param_types=['vlogdefine', 'vlogparam'],
+                                   tool_options=_tool_options,
+                                   ref_dir=edition)
+
+            # Each edition performs checks on the QSYS files present, so
+            # provide a minimal example
+            with open(os.path.join(tf.work_root, "qsys_file"), 'w') as f:
                 f.write(qsys_file.format(qsys_fill[edition]))
 
-            backend.configure()
+            tf.backend.configure()
+            tf.compare_files(['Makefile', tf.test_name + '.tcl'])
 
-            compare_files(ref_dir, work_root, ['Makefile',
-                                               name+'.tcl'])
-
-            backend.build()
-            compare_files(ref_dir, work_root, test_sets[edition][pnr])
+            tf.backend.build()
+            tf.compare_files(test_sets[edition][pnr])

--- a/tests/test_rivierapro.py
+++ b/tests/test_rivierapro.py
@@ -1,41 +1,36 @@
-import pytest
-import copy
+import filecmp
+import os
+from edalize_common import make_edalize_test, tests_dir
 
-def test_rivierapro():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam']
-    name         = 'test_rivierapro_0'
-    tool         = 'rivierapro'
+def test_rivierapro(make_edalize_test):
     tool_options = {
-        'vlog_options' : ['some', 'vlog_options'],
-        'vsim_options' : ['a', 'few', 'vsim_options'],
+        'vlog_options': ['some', 'vlog_options'],
+        'vsim_options': ['a', 'few', 'vsim_options'],
     }
 
-    #FIXME: Add VPI tests
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options, use_vpi=False)
-    backend.configure()
+    # FIXME: Add VPI tests
+    tf = make_edalize_test('rivierapro',
+                           tool_options=tool_options)
+    tf.backend.configure()
 
-    compare_files(ref_dir, work_root, [
-        'edalize_build_rtl.tcl',
-        'edalize_launch.tcl',
-        'edalize_main.tcl',
-    ])
+    tf.compare_files(['edalize_build_rtl.tcl',
+                      'edalize_launch.tcl',
+                      'edalize_main.tcl'])
 
-    orig_env = copy.deepcopy(os.environ)
-    os.environ['ALDEC_PATH'] = os.path.join(tests_dir, 'mock_commands')
+    orig_env = os.environ.copy()
+    try:
+        os.environ['ALDEC_PATH'] = os.path.join(tests_dir, 'mock_commands')
 
-    backend.build()
-    os.makedirs(os.path.join(work_root, 'work'))
+        tf.backend.build()
+        os.makedirs(os.path.join(tf.work_root, 'work'))
 
-    compare_files(ref_dir, work_root, ['vsim.cmd'])
+        tf.compare_files(['vsim.cmd'])
 
-    backend.run()
+        tf.backend.run()
 
-    with open(os.path.join(ref_dir, 'vsim2.cmd')) as fref, open(os.path.join(work_root, 'vsim.cmd')) as fgen:
-        assert fref.read() == fgen.read()
-
-    os.environ = orig_env
+        assert filecmp.cmp(os.path.join(tf.ref_dir, 'vsim2.cmd'),
+                           os.path.join(tf.work_root, 'vsim.cmd'),
+                           shallow=False)
+    finally:
+        os.environ = orig_env

--- a/tests/test_spyglass.py
+++ b/tests/test_spyglass.py
@@ -1,65 +1,36 @@
-import pytest
+from edalize_common import make_edalize_test, tests_dir
 
 
-def test_spyglass_defaults():
+def run_spyglass_test(tf):
+    tf.backend.configure()
+
+    tf.compare_files(['Makefile',
+                      'spyglass-run-design_read.tcl',
+                      'spyglass-run-lint_lint_rtl.tcl',
+                      tf.test_name + '.prj'])
+
+    tf.backend.build()
+    tf.compare_files(['spyglass.cmd'])
+
+
+def test_spyglass_defaults(make_edalize_test):
     """ Test if the SpyGlass backend picks up the tool defaults """
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir = os.path.join(tests_dir, __name__, 'defaults')
-    paramtypes = ['vlogdefine', 'vlogparam']
-    name = 'test_spyglass_0'
-    tool = 'spyglass'
-    tool_options = {}
-
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options)
-    backend.configure()
-
-    compare_files(ref_dir, work_root, [
-        'Makefile',
-        'spyglass-run-design_read.tcl',
-        'spyglass-run-lint_lint_rtl.tcl',
-        name + '.prj',
-    ])
-
-    backend.build()
-    compare_files(ref_dir, work_root, [
-        'spyglass.cmd',
-    ])
+    tf = make_edalize_test('spyglass',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           ref_dir='defaults')
+    run_spyglass_test(tf)
 
 
-def test_spyglass_tooloptions():
+def test_spyglass_tooloptions(make_edalize_test):
     """ Test passing tool options to the Spyglass backend """
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir = os.path.join(tests_dir, __name__, 'tooloptions')
-    paramtypes = ['vlogdefine', 'vlogparam']
-    name = 'test_spyglass_0'
-    tool = 'spyglass'
     tool_options = {
         'methodology': 'GuideWare/latest/block/rtl_somethingelse',
         'goals': ['lint/lint_rtl', 'some/othergoal'],
         'spyglass_options': ['handlememory yes'],
         'rule_parameters': ['handle_static_caselabels yes'],
     }
-
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options)
-    backend.configure()
-
-    compare_files(ref_dir, work_root, [
-        'Makefile',
-        'spyglass-run-design_read.tcl',
-        'spyglass-run-lint_lint_rtl.tcl',
-        'spyglass-run-some_othergoal.tcl',
-        name + '.prj',
-    ])
-
-    backend.build()
-    compare_files(ref_dir, work_root, [
-        'spyglass.cmd',
-    ])
+    tf = make_edalize_test('spyglass',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           ref_dir='tooloptions',
+                           tool_options=tool_options)
+    run_spyglass_test(tf)

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,60 +1,37 @@
-import pytest
+from edalize_common import make_edalize_test
 
 
-def test_vcs_tool_options():
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
+def run_vcs_test(tf):
+    tf.backend.configure()
 
-    ref_dir = os.path.join(tests_dir, __name__, 'tool_options')
-    paramtypes = ['plusarg', 'vlogdefine', 'vlogparam']
-    name = 'test_vcs_tool_options_0'
-    tool = 'vcs'
+    tf.compare_files(['Makefile', tf.test_name + '.scr'])
+
+    tf.backend.build()
+    tf.compare_files(['vcs.cmd'])
+
+    tf.backend.run()
+    tf.compare_files(['run.cmd'])
+
+
+def test_vcs_tool_options(make_edalize_test):
     tool_options = {
         'vcs_options'  : [ '-debug_access+pp', '-debug_access+all' ],
         'run_options'  : [ '-licqueue' ],
     }
-
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options, use_vpi=False)
-    backend.configure()
-
-    compare_files(ref_dir, work_root, ['Makefile', name + '.scr' ])
-
-    backend.build()
-    compare_files(ref_dir, work_root, ['vcs.cmd'])
-
-    backend.run()
-
-    compare_files(ref_dir, work_root, ['run.cmd'])
+    tf = make_edalize_test('vcs',
+                           test_name='test_vcs_tool_options_0',
+                           ref_dir='tool_options',
+                           tool_options=tool_options)
+    run_vcs_test(tf)
 
 
-def test_vcs_no_tool_options():
+def test_vcs_no_tool_options(make_edalize_test):
+    tf = make_edalize_test('vcs', ref_dir='no_tool_options')
+    run_vcs_test(tf)
+
+
+def test_vcs_minimal(tmpdir):
     import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir      = os.path.join(tests_dir, __name__, 'no_tool_options')
-    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam']
-    name         = 'test_vcs_0'
-    tool         = 'vcs'
-    tool_options = {}
-
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options, use_vpi=False)
-    backend.configure()
-
-    compare_files(ref_dir, work_root, ['Makefile', name + '.scr' ])
-
-    backend.build()
-    compare_files(ref_dir, work_root, ['vcs.cmd'])
-
-    backend.run()
-
-    compare_files(ref_dir, work_root, ['run.cmd'])
-
-def test_vcs_minimal():
-    import os
-    import shutil
-    import tempfile
 
     from edalize import get_edatool
 
@@ -64,7 +41,7 @@ def test_vcs_minimal():
     os.environ['PATH'] = os.path.join(tests_dir, 'mock_commands')+':'+os.environ['PATH']
     tool = 'vcs'
     name = 'test_'+tool+'_minimal_0'
-    work_root = tempfile.mkdtemp(prefix=tool+'_')
+    work_root = str(tmpdir)
 
     edam = {'name'         : name,
                'toplevel' : 'top'}
@@ -80,3 +57,4 @@ def test_vcs_minimal():
     backend.run()
 
     compare_files(ref_dir, work_root, ['run.cmd'])
+

--- a/tests/test_veribleformat.py
+++ b/tests/test_veribleformat.py
@@ -1,23 +1,13 @@
-import pytest
+from edalize_common import make_edalize_test
 
 
-def test_veribleformat_default():
+def test_veribleformat_default(make_edalize_test):
     """ Test the format mode of Verible """
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir = os.path.join(tests_dir, __name__, 'default')
-    paramtypes = ['vlogdefine', 'vlogparam']
-    name = 'test_verible'
-    tool = 'veribleformat'
-    tool_options = {}
-
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options)
-    backend.configure()
-    backend.build()
-    backend.run()
-    compare_files(ref_dir, work_root, [
-        'verilog_format.cmd',
-    ])
+    tf = make_edalize_test('veribleformat',
+                           test_name='test_verible',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           ref_dir='default')
+    tf.backend.configure()
+    tf.backend.build()
+    tf.backend.run()
+    tf.compare_files(['verilog_format.cmd'])

--- a/tests/test_veriblelint.py
+++ b/tests/test_veriblelint.py
@@ -1,23 +1,13 @@
-import pytest
+from edalize_common import make_edalize_test
 
 
-def test_veriblelint_default():
+def test_veriblelint_default(make_edalize_test):
     """ Test the lint mode of Verible """
-    import os
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir = os.path.join(tests_dir, __name__, 'lint')
-    paramtypes = ['vlogdefine', 'vlogparam']
-    name = 'test_verible'
-    tool = 'veriblelint'
-    tool_options = {}
-
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options)
-    backend.configure()
-    backend.build()
-    backend.run()
-    compare_files(ref_dir, work_root, [
-        'verilog_lint.cmd',
-    ])
+    tf = make_edalize_test('veriblelint',
+                           test_name='test_verible',
+                           param_types=['vlogdefine', 'vlogparam'],
+                           ref_dir='lint')
+    tf.backend.configure()
+    tf.backend.build()
+    tf.backend.run()
+    tf.compare_files(['verilog_lint.cmd'])

--- a/tests/test_verilator.py
+++ b/tests/test_verilator.py
@@ -1,83 +1,49 @@
-import pytest
+from edalize_common import make_edalize_test
 
-def test_verilator_cc():
-    import os.path
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
 
+def test_verilator_cc(make_edalize_test):
     mode = 'cc'
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['cmdlinearg', 'plusarg', 'vlogdefine', 'vlogparam']
-    name         = 'test_verilator_0'
-    tool         = 'verilator'
     tool_options = {
         'libs' : ['-lelf'],
         'mode' : mode,
         'verilator_options' : ['-Wno-fatal', '--trace'],
         'make_options' : ['OPT_FAST=-O2'],
     }
+    tf = make_edalize_test('verilator',
+                           param_types=['cmdlinearg', 'plusarg',
+                                        'vlogdefine', 'vlogparam'],
+                           tool_options=tool_options)
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
+    tf.backend.configure()
 
-    backend.configure()
+    tf.compare_files(['Makefile'])
+    tf.compare_files(['config.mk', tf.test_name + '.vc'], ref_subdir=mode)
 
-    compare_files(ref_dir, work_root, ['Makefile'])
+    tf.copy_to_work_root('Vtop_module')
+    tf.backend.run()
 
-    compare_files(os.path.join(ref_dir, mode),
-                  work_root,
-                  ['config.mk', name+'.vc'])
+    tf.compare_files(['run.cmd'])
 
-    dummy_exe = 'Vtop_module'
-    shutil.copy(os.path.join(ref_dir, dummy_exe),
-                os.path.join(work_root, dummy_exe))
-    backend.run()
 
-    compare_files(ref_dir, work_root, ['run.cmd'])
-
-def test_verilator_sc():
-    import os.path
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
+def test_verilator_sc(make_edalize_test):
     mode = 'sc'
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = []
-    name         = 'test_verilator_0'
-    tool         = 'verilator'
-    tool_options = {
-        'mode' : mode,
-    }
+    tf = make_edalize_test('verilator',
+                           param_types=[],
+                           tool_options={'mode': mode})
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
+    tf.backend.configure()
 
-    backend.configure()
+    tf.compare_files(['Makefile'])
+    tf.compare_files(['config.mk', tf.test_name + '.vc'], ref_subdir=mode)
 
-    compare_files(ref_dir, work_root, ['Makefile'])
 
-    compare_files(os.path.join(ref_dir, mode),
-                  work_root,
-                  ['config.mk', name+'.vc'])
-
-def test_verilator_lint_only():
-    import os.path
-    import shutil
-    from edalize_common import compare_files, setup_backend, tests_dir
-
+def test_verilator_lint_only(make_edalize_test):
     mode = 'lint-only'
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = []
-    name         = 'test_verilator_0'
-    tool         = 'verilator'
-    tool_options = {
-        'mode' : mode,
-    }
+    tf = make_edalize_test('verilator',
+                           param_types=[],
+                           tool_options={'mode': mode})
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
+    tf.backend.configure()
 
-    backend.configure()
-
-    compare_files(ref_dir, work_root, ['Makefile'])
-
-    compare_files(os.path.join(ref_dir, mode),
-                  work_root,
-                  ['config.mk', name+'.vc'])
+    tf.compare_files(['Makefile'])
+    tf.compare_files(['config.mk', tf.test_name + '.vc'], ref_subdir=mode)

--- a/tests/test_vunit.py
+++ b/tests/test_vunit.py
@@ -1,29 +1,19 @@
 import pytest
 import os.path
 from unittest.mock import patch, MagicMock
+from edalize_common import make_edalize_test
 
 
-def test_vunit_codegen():
-    from edalize_common import compare_files, setup_backend, tests_dir
-
-    ref_dir = os.path.join(tests_dir, __name__)
-    paramtypes = ['cmdlinearg']
-    name = 'test_vunit_0'
-    tool = 'vunit'
-    tool_options = {}
-
-    (backend, work_root) = setup_backend(
-        paramtypes, name, tool, tool_options, use_vpi=False)
-
-    backend.configure()
-    compare_files(ref_dir, work_root, ['run.py'])
+def test_vunit_codegen(make_edalize_test):
+    tf = make_edalize_test('vunit', param_types=['cmdlinearg'])
+    tf.backend.configure()
+    tf.compare_files(['run.py'])
 
 
-def test_vunit_hooks():
+def test_vunit_hooks(tmpdir):
     from edalize_common import tests_dir
 
     import subprocess
-    import tempfile
     import sys
     import importlib.util
     from unittest import mock
@@ -34,7 +24,7 @@ def test_vunit_hooks():
     ref_dir = os.path.join(tests_dir, __name__, 'minimal')
     tool = 'vunit'
     name = 'test_' + tool + '_minimal_0'
-    work_root = tempfile.mkdtemp(prefix = tool + '_')
+    work_root = str(tmpdir)
 
     files = [{'name' : os.path.join(ref_dir, 'vunit_runner_test.py'),
               'file_type' : 'pythonSource-3.7'},

--- a/tests/test_xsim.py
+++ b/tests/test_xsim.py
@@ -1,29 +1,26 @@
-def test_xsim():
-    import os
-    from edalize_common import compare_files, setup_backend, tests_dir
+from edalize_common import make_edalize_test
+import os
 
-    ref_dir      = os.path.join(tests_dir, __name__)
-    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam', 'generic']
-    name         = 'test_xsim_0'
-    tool         = 'xsim'
+
+def test_xsim(make_edalize_test):
     tool_options = {'xelab_options' : ['some', 'xelab_options'],
                     'xsim_options'  : ['a', 'few', 'xsim_options']}
+    paramtypes   = ['plusarg', 'vlogdefine', 'vlogparam', 'generic']
 
-    (backend, work_root) = setup_backend(paramtypes, name, tool, tool_options)
-    backend.configure()
+    tf = make_edalize_test('xsim',
+                           tool_options=tool_options,
+                           param_types=paramtypes)
 
-    compare_files(ref_dir, work_root, ['config.mk',
-                                       'Makefile',
-                                       name+'.prj',
-    ])
+    tf.backend.configure()
+    tf.compare_files(['config.mk', 'Makefile', tf.test_name + '.prj'])
 
-    backend.build()
-    compare_files(ref_dir, work_root, ['xelab.cmd'])
+    tf.backend.build()
+    tf.compare_files(['xelab.cmd'])
 
-    xsimkdir = os.path.join(work_root, 'xsim.dir', name)
+    xsimkdir = os.path.join(tf.work_root, 'xsim.dir', tf.test_name)
     os.makedirs(xsimkdir)
     with open(os.path.join(xsimkdir, 'xsimk'), 'w') as f:
         f.write("I am a compiled simulation kernel\n")
-    backend.run()
+    tf.backend.run()
 
-    compare_files(ref_dir, work_root, ['xsim.cmd'])
+    tf.compare_files(['xsim.cmd'])


### PR DESCRIPTION
This patch was actually inspired by trying to stop the tests leaving
temporary directories in /tmp. But it turns out there was a lot of
repeated boilerplate in tests, where they call setup_backend with
pretty standard arguments.

There's now a TestFixture class defined in edalize_common.py. Objects
of type TestFixture are called "tf". We create these TestFixture
objects with a "make_edalize_test" pytest fixture. This is a factory
because it lets the individual tests customize things like
param_types, ref_dir etc.

The changes to tests/test_*.py are pretty mechanical; the interesting
code changes are probably in tests/edalize_common.py.