### PR TITLE
Veriblelint: Support multiple config files

### DIFF
--- a/edalize/veriblelint.py
+++ b/edalize/veriblelint.py
@@ -64,10 +64,8 @@ class Veriblelint(Edatool):
 
         lint_fail = False
         args = self._get_tool_args()
-        if len(config_files_filtered) > 1:
-            raise RuntimeError("Too many Verible lint rule files specified")
-        elif len(config_files_filtered) == 1:
-            args.append('--rules_config=' + config_files_filtered[0])
+        if config_files_filtered:
+            args.append('--rules_config=' + ','.join(config_files_filtered))
 
         for src_file in src_files_filtered:
             cmd = ['verilog_lint'] + args + [src_file]

--- a/tests/edalize_common.py
+++ b/tests/edalize_common.py
@@ -127,7 +127,8 @@ FILES = [
     {'name' : 'cpp_file.cpp' , 'file_type' : 'cppSource'},
     {'name' : 'c_header.h'   , 'file_type' : 'cSource', 'is_include_file' : True},
     {'name' : 'c_header.h'   , 'file_type' : 'cppSource', 'is_include_file' : True},
-    {'name' : 'config.vbl'   , 'file_type' : 'veribleLintRules'}
+    {'name' : 'config.vbl'   , 'file_type' : 'veribleLintRules'},
+    {'name' : 'config2.vbl'  , 'file_type' : 'veribleLintRules'},
 ]
 """Files of all supported file types."""
 

--- a/tests/test_veriblelint/lint/verilog_lint.cmd
+++ b/tests/test_veriblelint/lint/verilog_lint.cmd
@@ -1,3 +1,3 @@
---lint_fatal --parse_fatal --rules_config=config.vbl sv_file.sv
---lint_fatal --parse_fatal --rules_config=config.vbl vlog_file.v
---lint_fatal --parse_fatal --rules_config=config.vbl vlog05_file.v
+--lint_fatal --parse_fatal --rules_config=config.vbl,config2.vbl sv_file.sv
+--lint_fatal --parse_fatal --rules_config=config.vbl,config2.vbl vlog_file.v
+--lint_fatal --parse_fatal --rules_config=config.vbl,config2.vbl vlog05_file.v

--- a/tests/test_vivado/test_vivado_0.tcl
+++ b/tests/test_vivado/test_vivado_0.tcl
@@ -27,6 +27,7 @@ read_mem bootrom.mem
 add_files -norecurse c_file.c
 add_files -norecurse cpp_file.cpp
 add_files -norecurse config.vbl
+add_files -norecurse config2.vbl
 
 set_property include_dirs [list . .] [get_filesets sources_1]
 set_property top top_module [current_fileset]


### PR DESCRIPTION
Since https://github.com/google/verible/issues/293 Verible lint supports
multiple rules files; add support for that to edalize.

I didn't add any version detection for Verible since we're currently
assuming `master` of Verible for edalize, as long as Verible hasn't done
a stable release yet.

Fixes #153