### PR TITLE
Modelsim should error on compilation failure

### DIFF
--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -176,6 +176,7 @@ class Modelsim(Edatool):
 
     def configure_main(self):
         tcl_main = open(os.path.join(self.work_root, "edalize_main.tcl"), 'w')
+        tcl_main.write("onerror { quit -code 1; }\n")
         tcl_main.write("do edalize_build_rtl.tcl\n")
 
         self._write_build_rtl_tcl_file(tcl_main)


### PR DESCRIPTION
A while ago I pushed a change to ensure that errors that occurred during a simulation could be propagated through make to ensure FuseSoC could reflect a simulation failure to a CI system.

I've just noticed something similar with compile time errors during the 'work' Makefile target under certain conditions. If a FuseSoC target uses modelsim to simulate something, it is possible for failures to not generate an error in the following circumstances:

* The files needed to run the simulation are all syntactically valid and should compile
* An unrelated file, that isn't needed for the specific simulation but is included in the same fileset, has a syntax error
* The unrelated file occurs later in the filesets than all files required for the simulation

In this case, modelsim is able to successfully compile enough of the files for a simulation to be performed, even though there are files with syntax errors it has been asked to compile. Normally this would be caught by a test bench not being able to elaborate the relevant file, but in an example I've seen locally we hadn't yet written the test for the incorrect file. Instead of getting a compile error though, ModelSim returned exit status 0 and our CI setup did not notice the invalid syntax.

This PR adds 'onerror' handling to the edalize_main.tcl file. If a file fails to compile, the onerror code block is executed, which ensures a non zero error status is passed up to make. This prevents the 'run' target from being reached if uncompilable code is present.