### PR TITLE
setup.py: move pytest to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,13 @@ setup(
         "Topic :: Utilities",
     ],
     install_requires=[
-        'pytest>=3.3.0',
         # 2.11.0 and .1 introduced an incompatible change in template output,
         # which was fixed in 2.11.2 and later.
         # https://github.com/pallets/jinja/issues/1138
         'Jinja2 >=2.8, !=2.11.0, !=2.11.1',
     ],
     tests_require=[
+        'pytest>=3.3.0',
         'vunit_hdl>=4.0.8'
     ],
     # Supported Python versions: 3.5+


### PR DESCRIPTION
pytest is not actually a runtime dependency, it is only needed for the
tests. Having it in install_requires can be a problem. One example would
be pkg_resources usage, as seen in this[1] downstream bug report.

[1] https://bugs.archlinux.org/task/67318

Signed-off-by: Filipe Laíns <lains@archlinux.org>