### PR TITLE
Use python3, rather than python, in test mock_commands

### DIFF
--- a/tests/mock_commands/arachne-pnr
+++ b/tests/mock_commands/arachne-pnr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/ascentlint
+++ b/tests/mock_commands/ascentlint
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 with open('ascentlint.cmd', 'w') as f:

--- a/tests/mock_commands/diamondc
+++ b/tests/mock_commands/diamondc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/ghdl
+++ b/tests/mock_commands/ghdl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/icepack
+++ b/tests/mock_commands/icepack
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/ip-generate
+++ b/tests/mock_commands/ip-generate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/iverilog
+++ b/tests/mock_commands/iverilog
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/iverilog-vpi
+++ b/tests/mock_commands/iverilog-vpi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/nextpnr-ice40
+++ b/tests/mock_commands/nextpnr-ice40
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/qsys-generate
+++ b/tests/mock_commands/qsys-generate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_asm
+++ b/tests/mock_commands/quartus_asm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_dse
+++ b/tests/mock_commands/quartus_dse
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_fit
+++ b/tests/mock_commands/quartus_fit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_map
+++ b/tests/mock_commands/quartus_map
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_sh
+++ b/tests/mock_commands/quartus_sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_sta
+++ b/tests/mock_commands/quartus_sta
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/quartus_syn
+++ b/tests/mock_commands/quartus_syn
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/sg_shell
+++ b/tests/mock_commands/sg_shell
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/vcs
+++ b/tests/mock_commands/vcs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 
@@ -8,7 +8,7 @@ output_file = sys.argv[sys.argv.index('-o')+1]
 # output_file, when executed, will record the arguments it has been called with
 # in a file `run.cmd`
 with open(output_file, 'w') as f:
-    s = """#!/usr/bin/env python
+    s = """#!/usr/bin/env python3
 import sys
 with open('run.cmd', 'w') as f:
     f.write(' '.join(sys.argv[1:]) + '\\n')

--- a/tests/mock_commands/verible-verilog-format
+++ b/tests/mock_commands/verible-verilog-format
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 with open('verible-verilog-format.cmd', 'a') as f:

--- a/tests/mock_commands/verible-verilog-lint
+++ b/tests/mock_commands/verible-verilog-lint
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 with open('verible-verilog-lint.cmd', 'a') as f:

--- a/tests/mock_commands/vivado
+++ b/tests/mock_commands/vivado
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/vsim
+++ b/tests/mock_commands/vsim
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/xtclsh
+++ b/tests/mock_commands/xtclsh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tests/mock_commands/yosys
+++ b/tests/mock_commands/yosys
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
Recently Debian unstable, at least, has uninstalled the "python"
binary by default. Since we require Python 3 anyway, let's use that.