### PR TITLE
added missing 'import logging'

### DIFF
--- a/edalize/yosys.py
+++ b/edalize/yosys.py
@@ -6,7 +6,6 @@ from edalize.edatool import Edatool
 
 logger = logging.getLogger(__name__)
 
-
 class Yosys(Edatool):
 
     argtypes = ['vlogdefine', 'vlogparam']

--- a/edalize/yosys.py
+++ b/edalize/yosys.py
@@ -1,6 +1,11 @@
+
+import logging
 import os.path
 
 from edalize.edatool import Edatool
+
+logger = logging.getLogger(__name__)
+
 
 class Yosys(Edatool):
 


### PR DESCRIPTION
Fix for logger not imported in yosys.py issue #189