### PR TITLE
Add RTD configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+sphinx:
+  configuration: doc/conf.py
+
+formats:
+  - pdf
+
+python:
+  install:
+    - requirements: doc/requirements.txt
+


### PR DESCRIPTION
ReadTheDocs can be configured through an in-tree configuration file. Add
one to fix the build, which is currently using Python 2.