### PR TITLE
[doc] Require Sphinx 3 at least

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,7 +36,7 @@ release = '0.1.3'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '3.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx>=3.0
 vunit_hdl
 sphinx_rtd_theme
 sphinx-autodoc-typehints


### PR DESCRIPTION
We use sphinx-autodoc-typehints in our documentation, which needs Sphinx
3 at least. It is actually listed as dependency there, but pip seems to
be not overly concerned to get that right.