### PR TITLE
Run pnmainc instead of diamondc if using Windows.

### DIFF
--- a/edalize/diamond.py
+++ b/edalize/diamond.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+import sys
 
 from edalize.edatool import Edatool
 
@@ -99,8 +100,13 @@ prj_project close
         return ''
 
     def build_main(self):
-        self._run_tool('diamondc', [self.name+'.tcl'], quiet=True)
-        self._run_tool('diamondc', [self.name+'_run.tcl'], quiet=True)
+        if sys.platform == 'win32':
+            tcl = 'pnmainc'
+        else:
+            tcl = 'diamondc'
+
+        self._run_tool(tcl, [self.name+'.tcl'], quiet=True)
+        self._run_tool(tcl, [self.name+'_run.tcl'], quiet=True)
 
     def run_main(self):
         pass


### PR DESCRIPTION
`diamondc` does not exist on Windows. Contrary to what Lattice [says](http://www.latticesemi.com/support/answerdatabase/5/5/2/5522) on the subject, `pmainc` is properly set up on Windows to "just work". `diamondc` should still work fine on Linux.