### PR TITLE
GHDL requires strings for boolean generics, not integers

### DIFF
--- a/edalize/ghdl.py
+++ b/edalize/ghdl.py
@@ -163,6 +163,6 @@ class Ghdl(Edatool):
             extra_options='EXTRA_OPTIONS='
             for d in [self.vlogparam, self.generic]:
                 for k,v in d.items():
-                    extra_options += ' -g{}={}'.format(k,self._param_value_str(v,'"'))
+                    extra_options += ' -g{}={}'.format(k,self._param_value_str(v,'"',bool_is_str=True))
             args.append(extra_options)
         self._run_tool(cmd, args)

--- a/tests/test_ghdl/test01/elab-run.cmd
+++ b/tests/test_ghdl/test01/elab-run.cmd
@@ -1,2 +1,2 @@
 -m --std=08 some analyze_options -P./libx top_module
--r --std=08 some analyze_options -P./libx top_module a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello
+-r --std=08 some analyze_options -P./libx top_module a few run_options -ggeneric_bool=true -ggeneric_int=42 -ggeneric_str=hello

--- a/tests/test_ghdl/test02/elab-run.cmd
+++ b/tests/test_ghdl/test02/elab-run.cmd
@@ -1,2 +1,2 @@
 -m --std=93c some analyze_options -P./libx top_module
--r --std=93c some analyze_options -P./libx top_module a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello
+-r --std=93c some analyze_options -P./libx top_module a few run_options -ggeneric_bool=true -ggeneric_int=42 -ggeneric_str=hello

--- a/tests/test_ghdl/test03/elab-run.cmd
+++ b/tests/test_ghdl/test03/elab-run.cmd
@@ -1,2 +1,2 @@
 -m --std=08 --ieee=synopsys -P./libx top_module
--r --std=08 --ieee=synopsys -P./libx top_module a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello
+-r --std=08 --ieee=synopsys -P./libx top_module a few run_options -ggeneric_bool=true -ggeneric_int=42 -ggeneric_str=hello

--- a/tests/test_ghdl/test04/elab-run.cmd
+++ b/tests/test_ghdl/test04/elab-run.cmd
@@ -1,2 +1,2 @@
 -m --std=08 some analyze_options -P./libx --work=libx --workdir=./libx vhdl_lfile
--r --std=08 some analyze_options -P./libx --work=libx --workdir=./libx vhdl_lfile a few run_options -ggeneric_bool=1 -ggeneric_int=42 -ggeneric_str=hello
+-r --std=08 some analyze_options -P./libx --work=libx --workdir=./libx vhdl_lfile a few run_options -ggeneric_bool=true -ggeneric_int=42 -ggeneric_str=hello


### PR DESCRIPTION
This was briefly mentioned in #131 but didn't make it into that commit.

A design with boolean generics will currently fail in elaboration with
an error like ``'value: '0' not in enumeration 'boolean'``. Edalize
currently uses its default of 1/0 for true/false, but GHDL expects the
true/false strings on the command line.