### PR TITLE
Avoid warning from deprecated NumPy float alias

### DIFF
--- a/edalize/quartus_reporting.py
+++ b/edalize/quartus_reporting.py
@@ -24,12 +24,6 @@ except ImportError as e:
     raise e
 
 try:
-    import numpy as np
-except ImportError as e:
-    logger.exception(import_msg, "numpy")
-    raise e
-
-try:
     import pandas as pd
 except ImportError as e:
     logger.exception(import_msg, "pandas")
@@ -109,7 +103,7 @@ class QuartusReporting(Reporting):
         # Get a frequency like 175.0 MHz and just return the numeric part
         freq = timing["Clocks"].set_index("Clock Name")["Frequency"]
         summary["constraint"] = (
-            freq.str.split(expand=True)[0].astype(np.float).to_dict()
+            freq.str.split(expand=True)[0].astype(float).to_dict()
         )
 
         # Find the Fmax summary table for the slowest corner, such as "Slow
@@ -127,7 +121,7 @@ class QuartusReporting(Reporting):
         ).string
 
         fmax = timing[slow_title].set_index("Clock Name")["Restricted Fmax"]
-        series = fmax.str.split(expand=True)[0].astype(np.float)
+        series = fmax.str.split(expand=True)[0].astype(float)
         summary["fmax"] = series.to_dict()
 
         return summary

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # The reporting modules have dependencies that shouldn't be required for
     # all Edalize users.
     extras_require={
-        "reporting": ["pyparsing", "numpy", "pandas"],
+        "reporting": ["pyparsing", "pandas"],
     },
     # Supported Python versions: 3.5+
     python_requires=">=3.5, <4",


### PR DESCRIPTION
Tests using Python 3.7+ report the following warning:
```
  /home/runner/work/edalize/edalize/.tox/py/lib/python3.7/site-packages/edalize/quartus_reporting.py:112:
DeprecationWarning: `np.float` is a deprecated alias for the builtin
`float`. To silence this warning, use `float` by itself. Doing this will
not modify any behavior and is safe. If you specifically wanted the
numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    freq.str.split(expand=True)[0].astype(np.float).to_dict()
```