### PR TITLE
Generate SVF bitstream file for ECP5

### DIFF
--- a/edalize/templates/trellis/trellis-makefile.j2
+++ b/edalize/templates/trellis/trellis-makefile.j2
@@ -11,7 +11,7 @@ all: $(TARGET).bit
 %.config: %.json
 	$(EDALIZE_LAUNCHER) nextpnr-ecp5 -l next.log $(NEXTPNR_OPTIONS) --lpf $(LPF_FILE) --json $? --textcfg $@
 %.bit: %.config
-	$(EDALIZE_LAUNCHER) ecppack $< $@
+	$(EDALIZE_LAUNCHER) ecppack --svf $(patsubst %.bit,%.svf, $@) $< $@
 
 build-gui: $(TARGET).json
 	$(EDALIZE_LAUNCHER) nextpnr-ecp5 $(NEXTPNR_OPTIONS) --json $? --textcfg $@ --gui


### PR DESCRIPTION
This change also generates the SVF file for ECP5 that can be used to program using OpenOCD.