### PR TITLE
Don't overcommit CPU on Verilator builds

### DIFF
--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -162,8 +162,8 @@ class Verilator(Edatool):
         if not 'mode' in self.tool_options:
             self.tool_options['mode'] = 'cc'
 
-        # Do parallel builds with <number of cpus> * 2 jobs.
-        make_job_count = multiprocessing.cpu_count() * 2
+        # Do parallel builds with <number of cpus>
+        make_job_count = multiprocessing.cpu_count()
         args = ['-j', str(make_job_count)]
 
         if self.tool_options['mode'] == 'lint-only':

--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -168,7 +168,6 @@ class Verilator(Edatool):
 
         if self.tool_options['mode'] == 'lint-only':
             args.append('V'+self.toplevel+'.mk')
-        _s = os.path.join(self.work_root, 'verilator.{}.log')
         self._run_tool('make', args, quiet=True)
 
     def run_main(self):


### PR DESCRIPTION
With recent CPUs and hyper-threading, performing 2x as many builds as CPU
(virtual) cores are available is more likely to slow down the build process
due to frequent context switches than it is to actually speed things up.