### PR TITLE
Fix Sphinx parse error in Vivado documentation

### DIFF
--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -53,7 +53,7 @@ class Vivado(Edatool):
                         'desc' : 'Source managment mode. Allowed values are None (unmanaged, default), DisplayOnly (automatically update sources) and All (automatically update sources and compile order)'},
                         {'name' : 'hw_target',
                         'type' : 'Description',
-                        'desc' : 'Board identifier (e.g. */xilinx_tcf/Digilent/123456789123A'},
+                        'desc' : 'A pattern matching a board identifier. Refer to the Vivado documentation for ``get_hw_targets`` for details. Example: ``*/xilinx_tcf/Digilent/123456789123A``'},
                     ]}
 
     """ Get tool version


### PR DESCRIPTION
The CAPI2 documentation and the edalize documentation are built
automatically from contents in the backends, and descriptions must
therefore be valid reStructuredText. Fix a case where this wasn't true.

Sphinx reported (in a FuseSoC build) due to the `*` not being followed
by another `*`:

```
capi2.rst:661:Inline emphasis start-string without end-string.
```