### PR TITLE
quartus: fix __init__ signature

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -56,11 +56,11 @@ class Quartus(Edatool):
     This calls the parent constructor, but also identifies whether
     the current system is using a Standard or Pro edition of Quartus.
     """
-    def __init__(self, edam=None, work_root=None, eda_api=None):
+    def __init__(self, edam=None, work_root=None, eda_api=None, verbose=False):
         if not edam:
             edam = eda_api
 
-        super(Quartus, self).__init__(edam, work_root)
+        super(Quartus, self).__init__(edam, work_root, verbose)
 
         # Acquire quartus_sh identification information from available tool if
         # possible. We always default to version 18.1 Standard if a problem is encountered


### PR DESCRIPTION
Since fusesoc commit f4fbaebfe9a140af9d8ae118ad8d0f5b38c75ee0 backend_class is always called with verbose explicit.
but quartus class has no verbose parameter and fusesoc fails with:
```bash
Traceback (most recent call last):
  File "/xx/.local/bin/fusesoc", line 33, in <module>
    sys.exit(load_entry_point('fusesoc', 'console_scripts', 'fusesoc')())
  File "/xx/fusesoc/main.py", line 757, in main
    fusesoc(args)
  File "/xx/.local/bin/main.py", line 747, in fusesoc
    args.func(cm, args)
  File "/xx/.local/bin/main.py", line 351, in run
    run_backend(
  File "/xx/.local/bin/main.py", line 446, in run_backend
    backend = backend_class(edam=edam, work_root=work_root, verbose=verbose)
TypeError: __init__() got an unexpected keyword argument 'verbose'
```