### PR TITLE
quartus: Introduce globalassign parameter

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -2,6 +2,7 @@
 # Licensed under the 2-Clause BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from collections import OrderedDict
 import logging
 import os.path
 import os
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class Quartus(Edatool):
 
-    argtypes = ['vlogdefine', 'vlogparam', 'generic']
+    argtypes = ['vlogdefine', 'vlogparam', 'generic', 'globalassign']
 
     # Define Standard edition to be our default version
     isPro = False
@@ -59,6 +60,8 @@ class Quartus(Edatool):
     def __init__(self, edam=None, work_root=None, eda_api=None, verbose=False):
         if not edam:
             edam = eda_api
+
+        self.globalassign = OrderedDict()
 
         super(Quartus, self).__init__(edam, work_root, verbose)
 
@@ -118,6 +121,7 @@ class Quartus(Edatool):
             'src_files'    : src_files,
             'incdirs'      : incdirs,
             'tool_options' : self.tool_options,
+            'globalassign' : self.globalassign,
             'toplevel'     : self.toplevel,
             'vlogparam'    : self.vlogparam,
             'vlogdefine'   : self.vlogdefine,

--- a/edalize/templates/quartus/quartus-project.tcl.j2
+++ b/edalize/templates/quartus/quartus-project.tcl.j2
@@ -1,6 +1,11 @@
 project_new {{ name }} -overwrite
 set_global_assignment -name FAMILY "{{ tool_options.family }}"
 set_global_assignment -name DEVICE {{ tool_options.device }}
+{% if globalassign %}
+{% for k, v in globalassign.items() %}
+set_global_assignment -name {{k}} {{v|param_value_str}}
+{% endfor %}
+{% endif %}
 {% if toplevel %}
 set_global_assignment -name TOP_LEVEL_ENTITY {{ toplevel }}
 {% endif %}

--- a/tests/test_quartus.py
+++ b/tests/test_quartus.py
@@ -45,7 +45,8 @@ def test_quartus(make_edalize_test):
             os.environ["FUSESOC_QUARTUS_EDITION"] = edition
 
             tf = make_edalize_test('quartus',
-                                   param_types=['vlogdefine', 'vlogparam'],
+                                   param_types=['vlogdefine', 'vlogparam',
+                                                'globalassign'],
                                    tool_options=_tool_options,
                                    ref_dir=edition)
 

--- a/tests/test_quartus/Pro/test_quartus_0.tcl
+++ b/tests/test_quartus/Pro/test_quartus_0.tcl
@@ -1,6 +1,9 @@
 project_new test_quartus_0 -overwrite
 set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSXFC6D6F31C8ES
+set_global_assignment -name globalassign_bool 1
+set_global_assignment -name globalassign_int 42
+set_global_assignment -name globalassign_str hello
 set_global_assignment -name TOP_LEVEL_ENTITY top_module
 set_global_assignment -name VHDL_INPUT_VERSION VHDL_2008
 set_parameter -name vlogparam_bool 1

--- a/tests/test_quartus/Standard/test_quartus_0.tcl
+++ b/tests/test_quartus/Standard/test_quartus_0.tcl
@@ -1,7 +1,7 @@
 project_new test_quartus_0 -overwrite
 set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSXFC6D6F31C8ES
-set_global_assignment -name globalassign_bool true
+set_global_assignment -name globalassign_bool 1
 set_global_assignment -name globalassign_int 42
 set_global_assignment -name globalassign_str hello
 set_global_assignment -name TOP_LEVEL_ENTITY top_module

--- a/tests/test_quartus/Standard/test_quartus_0.tcl
+++ b/tests/test_quartus/Standard/test_quartus_0.tcl
@@ -1,6 +1,9 @@
 project_new test_quartus_0 -overwrite
 set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSXFC6D6F31C8ES
+set_global_assignment -name globalassign_bool true
+set_global_assignment -name globalassign_int 42
+set_global_assignment -name globalassign_str hello
 set_global_assignment -name TOP_LEVEL_ENTITY top_module
 set_global_assignment -name VHDL_INPUT_VERSION VHDL_2008
 set_parameter -name vlogparam_bool 1


### PR DESCRIPTION
Sometime, it's required to add some `set_global_assignment`: to have access to SPI flash or to use some function pins as `REGULAR GPIO`.
This PR add `globalassign` in argtype list to complete the tcl with global assignment key/value