### PR TITLE
tests: fix test_reporting for ise

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -293,7 +293,7 @@ def test_picorv32_ise_spartan6_resources(picorv32_s6_data):
     # Check Control Set Information table
     df = rpt["Control Set Information"]
 
-    assert df["Clock Signal"].all() == "clk_BUFGP"
+    assert set(df["Clock Signal"]) == {"clk_BUFGP"}
     assert df.shape == (20, 6)
 
     rst_en = df[
@@ -672,7 +672,7 @@ def test_linux_on_litex_vexriscv_pipistrello_resources(
     df = rpt["IOB Properties"].set_index("IOB Name")
 
     ddr_io = df.filter(regex="ddram_*", axis=0)
-    assert ddr_io["IO Standard"].all() == "MOBILE_DDR"
+    assert set(ddr_io["IO Standard"]) == {"MOBILE_DDR"}
 
     # Check Control Set Information table
     df = rpt["Control Set Information"]


### PR DESCRIPTION
With panda 1.3.0 `pandas.core.series.Series.all()` return a `bool`
So, for ise's tests `assert df["Clock Signal"].all() == "clk_BUFGP"` and `assert ddr_io["IO Standard"].all() == "MOBILE_DDR"` fails.

This PR replace `all()` by using a `set` to reduce values to one element and compare this set with the expected value.