### PR TITLE
Output Vivado synth log to stdout

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -4,6 +4,11 @@ set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  # Vivado only outputs to stdout for jobs that are explicitly waited on with
+  # 'wait_on_run'. So launch and wait on synth then launch and wait on impl to
+  # get logging to stdout from both.
+  launch_runs synth_1{{ jobs }}
+  wait_on_run synth_1
   launch_runs impl_1 -to_step write_bitstream{{ jobs }}
   wait_on_run impl_1
   puts "Bitstream generation completed"

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
@@ -4,6 +4,11 @@ set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  # Vivado only outputs to stdout for jobs that are explicitly waited on with
+  # 'wait_on_run'. So launch and wait on synth then launch and wait on impl to
+  # get logging to stdout from both.
+  launch_runs synth_1
+  wait_on_run synth_1
   launch_runs impl_1 -to_step write_bitstream
   wait_on_run impl_1
   puts "Bitstream generation completed"

--- a/tests/test_vivado/test_vivado_0_run.tcl
+++ b/tests/test_vivado/test_vivado_0_run.tcl
@@ -4,6 +4,11 @@ set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  # Vivado only outputs to stdout for jobs that are explicitly waited on with
+  # 'wait_on_run'. So launch and wait on synth then launch and wait on impl to
+  # get logging to stdout from both.
+  launch_runs synth_1
+  wait_on_run synth_1
   launch_runs impl_1 -to_step write_bitstream
   wait_on_run impl_1
   puts "Bitstream generation completed"

--- a/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
+++ b/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
@@ -4,6 +4,11 @@ set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
 if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  # Vivado only outputs to stdout for jobs that are explicitly waited on with
+  # 'wait_on_run'. So launch and wait on synth then launch and wait on impl to
+  # get logging to stdout from both.
+  launch_runs synth_1
+  wait_on_run synth_1
   launch_runs impl_1 -to_step write_bitstream
   wait_on_run impl_1
   puts "Bitstream generation completed"


### PR DESCRIPTION
Previously only the implementation job would output to stdout. The
synthesis job only output to a seperate log file. It seems Vivado only
outputs to stdout from jobs that are explicitly waited on with
'wait_on_run'.