### PR TITLE
[xcelium] updated xcelium flow to a working state

### DIFF
--- a/doc/edam/api.rst
+++ b/doc/edam/api.rst
@@ -322,10 +322,8 @@ xcelium
 ================ ===================== ===========
 Field Name       Type                  Description
 ================ ===================== ===========
-xmvlog_options   List of String        Extra options for compilation with `xmvlog`
-xmvhdl_options   List of String        Extra options for compilation with `xmvhdl`
-xmsim_options    List of String        Extra options for running simulation with with `xsim`
-xrun_options     List of String        Extra options for invocation with with `xrun`
+elab_options     List of String        Compilation options for invocation with `xrun -elaborate`
+run_options      List of String        Extra options for invocation with with `xrun -R`
 ================ ===================== ===========
 
 xsim


### PR DESCRIPTION
the previous state of the xcelium flow was not working correctly.
I have created a new flow based on the existing flow - adding a lot more freedom for the user.

before there was a onestop for all flow - where compile and simulation was always executed.
the new flow breaks this into the natural steps of compile/elaborate
and another step for the simulation which is very useful if anywant is running a regression sweep or just want to update a c library or similar and don't want to be forced to recompile the full RTL code.

I also created the option of adding a prefix to the run command.
which is useful when using submission queues.

let me know what you guys think.