### PR TITLE
Add missing verbose argument to symbiyosys backend

### DIFF
--- a/edalize/symbiyosys.py
+++ b/edalize/symbiyosys.py
@@ -112,8 +112,8 @@ You can reproduce the example above with something like
         }
     }
 
-    def __init__(self, edam=None, work_root=None, eda_api=None):
-        super(Symbiyosys, self).__init__(edam, work_root, eda_api)
+    def __init__(self, edam=None, work_root=None, eda_api=None, verbose=True):
+        super(Symbiyosys, self).__init__(edam, work_root, eda_api, verbose)
 
         # Register Jinja filters
         self.jinja_env.filters["gen_reads"] = self._gen_reads


### PR DESCRIPTION
Like Quartus, this subclass of Edatool has its own `__init__` method.
The base class gained a "verbose" argument in 18f6a052 (November 2020)
and Fusesoc started using it in f4fbaebf (April 2021), which breaks
things.