### PR TITLE
feat_board_file_support: adding support for BD files

### DIFF
--- a/edalize/templates/vivado/vivado-project.tcl.j2
+++ b/edalize/templates/vivado/vivado-project.tcl.j2
@@ -1,9 +1,22 @@
 # Auto-generated project tcl file
 
+{% if tool_options.board_repo_paths -%}
+# Must be set before creating the project otherwise it is ignored.
+# Allows the user to provide local path to board files.
+set_param board.repoPaths {
+  {%- for path in tool_options.board_repo_paths %}
+  {{ path }}
+  {%- endfor %} }
+{%- endif %}
+
 create_project {{ name }} -force
 
 {% if tool_options.part -%}
 set_property part {{ tool_options.part }} [current_project]
+{%- endif %}
+
+{% if tool_options.board_part -%}
+set_property board_part {{ tool_options.board_part }} [current_project]
 {%- endif %}
 
 {% if has_vhdl2008 -%}
@@ -39,6 +52,15 @@ set_property include_dirs [list {{ incdirs|join(' ') }}] [get_filesets sources_1
 set_property top {{ toplevel }} [current_fileset]
 set_property source_mgmt_mode {{ tool_options.source_mgmt_mode if tool_options.source_mgmt_mode else "None" }} [current_project]
 
+{%- endif %}
+
+{% if bd_files -%}
+{%- for bd in bd_files %}
+report_ip_status
+upgrade_ip [get_ips -of_objects [get_bd_designs {{ bd }}]]
+set_property synth_checkpoint_mode None [get_files {{ bd }}]
+generate_target all [get_files {{ bd }}]
+{% endfor -%}
 {%- endif %}
 
 {% if has_xci -%}

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -33,11 +33,23 @@ class Vivado(Edatool):
         if api_ver == 0:
             return {
                 "description": "The Vivado backend executes Xilinx Vivado to build systems and program the FPGA",
+                'lists': [
+                    {
+                        'name': 'board_repo_paths',
+                        'type': 'String',
+                        'desc': 'Board repository paths. A list of paths to search for board files.'
+                    },
+                ],
                 "members": [
                     {
                         "name": "part",
                         "type": "String",
                         "desc": "FPGA part number (e.g. xc7a35tcsg324-1)",
+                    },
+                    {
+                        "name": "board_part",
+                        "type": "String",
+                        "desc": "Board part number (e.g. xilinx.com:kc705:part0:0.9)",
                     },
                     {
                         "name": "synth",
@@ -123,6 +135,7 @@ class Vivado(Edatool):
         has_vhdl2008 = False
         has_xci = False
         unused_files = []
+        bd_files = []
 
         for f in self.files:
             cmd = ""
@@ -151,6 +164,9 @@ class Vivado(Edatool):
                 cmd = "read_xdc -unmanaged"
             elif f["file_type"] == "mem":
                 cmd = "read_mem"
+            elif f["file_type"] == "bd":
+                cmd = 'read_bd'
+                bd_files.append(f["name"])
 
             if cmd:
                 if not self._add_include_dir(f, incdirs):
@@ -170,6 +186,7 @@ class Vivado(Edatool):
             "netlist_flow": bool(edif_files),
             "has_vhdl2008": has_vhdl2008,
             "has_xci": has_xci,
+            "bd_files": bd_files
         }
 
         self.render_template("vivado-project.tcl.j2", self.name + ".tcl", template_vars)


### PR DESCRIPTION
 - added support for the "bd" file_type for Vivado Block Designs. In the same
   way as there is XCI support, users can now provide a list of .bd files.
 - added two tool_options entries for board_part and board_repo_paths. The first
   allows a board_part property to be set in the project and the latter allows
   a local path outside of the tool installation to be used for board files.