### PR TITLE
Deprecate and remove Python 3.6 (EOL since 23 Dec 2021)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         #- { icon: 🍎, name: macos }
         #- { icon: 🧊, name: windows }
         pyver:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,6 @@ setup(
         "reporting": ["pyparsing", "pandas"],
     },
     # Supported Python versions: 3.6+
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
     scripts=["scripts/el_docker"],
 )


### PR DESCRIPTION
Close #294.
Coming from [#294](https://github.com/olofk/edalize/pull/294#issuecomment-1008122511).

This PR bumps the required Python version to `>=3.7`, since Python 3.6 was EOL in december 2021. Furthermore, it seems that Edalize does require Python 3.7 already. According to CI tests, Python 3.6 is failing since a month ago, when Icestorm backend was converted to the new API: https://github.com/olofk/edalize/commit/78584db87769a87dacac92d11f0f2dd2ac0723f8.