### PR TITLE
Fixed quotation for vhdl generics for Xilinx Xsim

### DIFF
--- a/edalize/xsim.py
+++ b/edalize/xsim.py
@@ -128,7 +128,7 @@ XSIM_OPTIONS  = {xsim_options}
             gen_param.update(self.generic)
             gen_param_args = " ".join(
                 [
-                    "--generic_top {}={}".format(k, self._param_value_str(v))
+                    '--generic_top "{}={}"'.format(k, self._param_value_str(v))
                     for k, v in gen_param.items()
                 ]
             )


### PR DESCRIPTION
Overrides fail without quotation marks, the PR fixes this issue.
Resolveses olofk/fusesoc#543

Related Xilinx support article: https://support.xilinx.com/s/article/64118