### PR TITLE
ISE backend: add support for specifying the JTAG chain index

### DIFF
--- a/doc/edam/api.rst
+++ b/doc/edam/api.rst
@@ -154,14 +154,15 @@ yosys_synth_options List of String        Options for Yosys Synthesis
 ise
 ~~~
 
-================ ===================== ===========
-Field Name       Type                  Description
-================ ===================== ===========
-family           String                FPGA family e.g. *spartan6*, *virtex5*
-device           String                Device identifier e.g. *xc6slx45*
-package          String                Device package e.g. *csg324*
-speed            String                Device speed grade e.g. *-2*
-================ ===================== ===========
+================== ===================== ===========
+Field Name         Type                  Description
+================== ===================== ===========
+family             String                FPGA family e.g. *spartan6*, *virtex5*
+device             String                Device identifier e.g. *xc6slx45*
+package            String                Device package e.g. *csg324*
+speed              String                Device speed grade e.g. *-2*
+board_device_index String                Specifies the FPGA's device number in the JTAG chain, starting at 1.
+================== ===================== ===========
 
 isim
 ~~~~

--- a/edalize/ise.py
+++ b/edalize/ise.py
@@ -56,8 +56,9 @@ project set "Generate Detailed MAP Report" true
 
 setMode -bscan
 setCable -port auto
-addDevice -p 1 -file {bit_file}
-program -p 1
+identify
+assignFile -p {board_device_index} -file {bit_file}
+program -p {board_device_index}
 saveCDF -file {cdf_file}
 quit
 """
@@ -87,6 +88,11 @@ quit
                         "name": "speed",
                         "type": "String",
                         "desc": "FPGA speed grade (e.g. -2)",
+                    },
+                    {
+                        "name": "board_device_index",
+                        "type": "String",
+                        "desc": "Specifies the FPGA's device number in the JTAG chain, starting at 1",
                     },
                 ],
             }
@@ -191,6 +197,7 @@ quit
                 pgm_file=pgm_file_name,
                 bit_file=os.path.join(self.work_root, self.toplevel + ".bit"),
                 cdf_file=os.path.join(self.work_root, self.toplevel + ".cdf"),
+                board_device_index=self.tool_options.get("board_device_index", "1"),
             )
         )
         pgm_file.close()


### PR DESCRIPTION
This fixes a problem that I've encountered while trying to run `fusesoc` Blinky on Digilent Spartan-S3E Starter board.

Namely, this Xilinx Impact batch doesn't work (failing with device ID mismatch):

```
setMode -bscan
setCable -port auto
addDevice -p 1 -file ./blinky.bit
program -p 1
quit
```
... because with more devices on the JTAG chain (`XCF04S` PROM and `XC2C64` CPLD in my case) it seems necessary to either specify the whole chain or scan it. 

With this change the chain is first scanned with `identify` and a file is then assigned to the device with `assignFile`:
```
setMode -bscan
setCable -port auto
identify 
assignFile -p 1 -file ./blinky.bit
program -p 1
quit
```

I've also added `board_device_index` parameter allowing for specifying chip JTAG chain location (defaults to 1).

Note: I'm not sure about impact (no pun intended) of this change on other boards, I've no hardware to check it. But I expect no issues.
