### PR TITLE
Fix formatting/CI check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 # formatters, linters, and other productivity tools before a commit.
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: "22.3.0"
     hooks:
       - id: black

--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -42,7 +42,7 @@ class Vivado(Edatool):
         },
         "board_repo_paths": {
             "type": "String",
-            "desc": "Board repository paths. A list of paths to search for board files."
+            "desc": "Board repository paths. A list of paths to search for board files.",
         },
         "pnr": {
             "type": "String",

--- a/tests/test_icestorm.py
+++ b/tests/test_icestorm.py
@@ -51,6 +51,7 @@ def test_icestorm_no_pcf(make_edalize_test):
 
     tf.backend.configure()
 
+
 def test_icestorm_multiple_pcf(make_edalize_test):
     files = [
         {"name": "pcf_file.pcf", "file_type": "PCF"},


### PR DESCRIPTION
Commit f764e7efa3e4b86553930e708db35b0bf7cc7953 broke the black formatting
CI check. Fix that.

Also update black to a version that works with recent version of the Click dependency.