### PR TITLE
Limit CPU usage in Verilator build #210

### DIFF
--- a/edalize/verilator.py
+++ b/edalize/verilator.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import logging
-import multiprocessing
 import os
 import logging
 
@@ -206,11 +205,7 @@ class Verilator(Edatool):
         logger.info("Building simulation model")
         if not "mode" in self.tool_options:
             self.tool_options["mode"] = "cc"
-
-        # Do parallel builds with <number of cpus>
-        make_job_count = multiprocessing.cpu_count()
-        args = ["-j", str(make_job_count)]
-
+        args = []
         if self.tool_options["mode"] == "lint-only":
             args.append("V" + self.toplevel + ".mk")
         self._run_tool("make", args, quiet=True)


### PR DESCRIPTION
Verilator builds previously used all available CPUs by calling Make with the -j<cpu_count>
argument. This is fine when running on your local machine but is not fine when running the
build in a professional environment where you are submitting the job to a cluster.

This update removes the -j<cpu_count> argument from the build step.  Users wishing to use
N CPUs for a build should instead pass the MAKEFLAGS environment variable when calling
fusesoc:

  export MAKEFLAGS=-jN; fusesoc ...