### PR TITLE
Restore Vivado run_main method; fixes #317

### DIFF
--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -97,6 +97,22 @@ class Vivado(Edatool):
     def configure_main(self):
         self.vivado.configure()
 
+    def run_main(self):
+        """
+        Program the FPGA.
+
+        For programming the FPGA a vivado tcl script is written that searches for the
+        correct FPGA board and then downloads the bitstream. The tcl script is then
+        executed in Vivado's batch mode.
+        """
+        if "pnr" in self.tool_options:
+            if self.tool_options["pnr"] == "vivado":
+                pass
+            elif self.tool_options["pnr"] == "none":
+                return
+
+        self._run_tool("make", ["pgm"])
+
     def build_pre(self):
         pass
 


### PR DESCRIPTION
It is currently not possible to program an FPGA using: ```fusesoc run --target=synth --run```
Restoring the Vivado run_main method fixes this issue ([#317](https://github.com/olofk/edalize/issues/317))
