### PR TITLE
Add fix for ISE path handling on Windows

### DIFF
--- a/edalize/ise.py
+++ b/edalize/ise.py
@@ -151,7 +151,7 @@ quit
                 )
             )
 
-        (src_files, incdirs) = self._get_fileset_files()
+        (src_files, incdirs) = self._get_fileset_files(force_slash = True) # ISE tcl doesn't like '\', so '/' is forced
 
         if incdirs:
             tcl_file.write(


### PR DESCRIPTION
By default, the ISE backend crashes when configuring a project on Windows, because the Tcl scripts don't handle Windows '\' path separators. Here's an example of the error when building the `blinky` project for the `pipistrello` target (which uses Xilinx ISE by default):
`INFO: Building
xtclsh fusesoc_utils_blinky_1.1.1.tcl
ERROR:TclTasksC:xfile_070: File(s) "./..src♀usesoc_utils_blinky_1.1.linky.v" cannot be found
    while executing
"xfile add ..\src\fusesoc_utils_blinky_1.1.1\blinky.v"
    (file "fusesoc_utils_blinky_1.1.1.tcl" line 21)
make: *** [Makefile:10: fusesoc_utils_blinky_1.1.1.xise] Error 1
←[1;31mERROR: Failed to build fusesoc:utils:blinky:1.1.1 : '['make']' exited with an error: 2←[0m`

This patch simply enables the option in _get_fileset_files to replace the path separators by default, for ISE projects.
Even on Windows, the '/' separator works just fine with Tcl.