### PR TITLE
Refactor and introduce get_tool_options in flow

### DIFF
--- a/edalize/flows/edaflow.py
+++ b/edalize/flows/edaflow.py
@@ -73,6 +73,9 @@ def merge_dict(d1, d2):
 
 
 class Edaflow(object):
+
+    FLOW = []
+
     @classmethod
     def get_flow_options(cls):
         flow_opts = cls.FLOW_OPTIONS.copy()
@@ -90,6 +93,36 @@ class Edaflow(object):
                     flow_opts[opt_name]["tool"] = tool_name
         return flow_opts
 
+    @classmethod
+    def get_tool_options(cls, flow_options):
+        return {}
+
+    # Takes a list of tool names and a dict of pre-defined tool options
+    # Imports the tool class for every tool in the list, extracts their
+    # tool options and return then all, except for the ones listed in
+    # flow_defined_tool_options
+    @classmethod
+    def get_filtered_tool_options(cls, tools, flow_defined_tool_options):
+        tool_opts = {}
+        for tool_name in tools:
+
+            # Get available tool options from each tool in the list
+            try:
+                class_tool_options = getattr(
+                    import_module(f"edalize.tools.{tool_name}"), tool_name.capitalize()
+                ).get_tool_options()
+            except ModuleNotFoundError:
+                raise RuntimeError(f"Could not find tool '{tool_name}'")
+            # Add them to the dict unless they are already set by the flow
+            filtered_tool_options = flow_defined_tool_options.get(tool_name, {})
+            for opt_name in class_tool_options:
+                # Filter out tool options that are already set by the flow
+                if not opt_name in filtered_tool_options:
+                    tool_opts[opt_name] = class_tool_options[opt_name]
+                    tool_opts[opt_name]["tool"] = tool_name
+
+        return tool_opts
+
     def extract_flow_options(self):
         # Extract flow options from the EDAM
         flow_options = {}
@@ -106,7 +139,7 @@ class Edaflow(object):
     def extract_tool_options(self):
         tool_options = {}
         edam_flow_opts = self.edam.get("flow_options", {})
-        for (tool_name, next_nodes, flow_defined_tool_options) in self.FLOW:
+        for (tool_name, next_nodes, flow_defined_tool_options) in self.flow:
 
             # Get the tool class
             ToolClass = getattr(
@@ -130,7 +163,7 @@ class Edaflow(object):
     def build_tool_graph(self):
         # Instantiate the tools
         nodes = {}
-        for (tool_name, next_nodes, flow_defined_tool_options) in self.FLOW:
+        for (tool_name, next_nodes, flow_defined_tool_options) in self.flow:
 
             # Instantiate the tool class
             tool_inst = getattr(
@@ -201,12 +234,18 @@ class Edaflow(object):
             last_script = script["name"]
         self.commands.add([], [hook_name], [last_script])
 
+    def configure_flow(self, flow_options):
+        return self.FLOW
+
     def __init__(self, edam, work_root, verbose=False):
         self.edam = edam
+        self.commands = EdaCommands()
 
         # Extract all options that affects the flow rather than
         # just a single tool
         self.flow_options = self.extract_flow_options()
+
+        self.flow = self.configure_flow(self.flow_options)
 
         # Rearrange tool_options so that each tool gets their
         # own tool_options
@@ -216,7 +255,6 @@ class Edaflow(object):
 
         self.stdout = None
         self.stderr = None
-        self.commands = EdaCommands()
 
     def set_run_command(self):
         self.commands.add([], ["run"], ["pre_run"])

--- a/edalize/flows/lint.py
+++ b/edalize/flows/lint.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os.path
+from importlib import import_module
 
 from edalize.flows.edaflow import Edaflow
 
@@ -12,10 +13,10 @@ class Lint(Edaflow):
 
     argtypes = ["vlogdefine", "vlogparam"]
 
-    FLOW = [
-        ("verilator", [], {"mode": "lint-only", "exe": "false", "make_options": []}),
+    FLOW_DEFINED_TOOL_OPTIONS = {
+        "verilator": {"mode": "lint-only", "exe": "false", "make_options": []},
         # verible, spyglass, ascentlint, slang...
-    ]
+    }
 
     FLOW_OPTIONS = {
         "frontends": {
@@ -29,23 +30,28 @@ class Lint(Edaflow):
         },
     }
 
-    def build_tool_graph(self):
+    @classmethod
+    def get_tool_options(cls, flow_options):
+        flow = flow_options.get("frontends", [])
+        tool = flow_options.get("tool")
+        if not tool:
+            raise RuntimeError("Flow 'lint' requires flow option 'tool' to be set")
+        flow.append(tool)
+
+        return cls.get_filtered_tool_options(flow, cls.FLOW_DEFINED_TOOL_OPTIONS)
+
+    def configure_flow(self, flow_options):
         tool = self.flow_options.get("tool", "")
         if not tool:
-            raise RuntimeError(
-                "'lint' backend requires flow option 'tool' to be defined"
-            )
-        tmp = [x for x in self.FLOW if x[0] == tool]
-        self.FLOW = tmp
+            raise RuntimeError("Flow 'lint' requires flow option 'tool' to be set")
+        flow = [(tool, [], self.FLOW_DEFINED_TOOL_OPTIONS.get(tool, {}))]
+        # Add any user-specified frontends to the flow
+        next_tool = tool
 
-        # Note: This makes an assumption that the first tool in self.FLOW is
-        # a single entry point to the flow
-        next_tool = self.FLOW[0][0]
-
-        for frontend in reversed(self.flow_options.get("frontends", [])):
-            self.FLOW[0:0] = [(frontend, [next_tool], {})]
+        for frontend in reversed(flow_options.get("frontends", [])):
+            flow[0:0] = [(frontend, [next_tool], {})]
             next_tool = frontend
-        return super().build_tool_graph()
+        return flow
 
     def configure_tools(self, nodes):
         super().configure_tools(nodes)

--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -29,39 +29,39 @@ class Vivado(Edatool):
 
     TOOL_OPTIONS = {
         "part": {
-            "type": "String",
+            "type": "str",
             "desc": "FPGA part number (e.g. xc7a35tcsg324-1)",
         },
         "synth": {
-            "type": "String",
+            "type": "str",
             "desc": "Synthesis tool. Allowed values are vivado or none.",
         },
         "board_part": {
-            "type": "String",
+            "type": "str",
             "desc": "Board part number (e.g. xilinx.com:kc705:part0:0.9)",
         },
         "board_repo_paths": {
-            "type": "String",
+            "type": "str",
             "desc": "Board repository paths. A list of paths to search for board files.",
         },
         "pnr": {
-            "type": "String",
+            "type": "str",
             "desc": "P&R tool. Allowed values are vivado (default) and none (to just run synthesis)",
         },
         "jobs": {
-            "type": "Integer",
+            "type": "int",
             "desc": "Number of jobs. Useful for parallelizing OOC (Out Of Context) syntheses.",
         },
         "jtag_freq": {
-            "type": "Integer",
+            "type": "int",
             "desc": "The frequency for jtag communication",
         },
         "source_mgmt_mode": {
-            "type": "String",
+            "type": "str",
             "desc": "Source managment mode. Allowed values are None (unmanaged, default), DisplayOnly (automatically update sources) and All (automatically update sources and compile order)",
         },
         "hw_target": {
-            "type": "Description",
+            "type": "str",
             "desc": "A pattern matching a board identifier. Refer to the Vivado documentation for ``get_hw_targets`` for details. Example: ``*/xilinx_tcf/Digilent/123456789123A``",
         },
     }

--- a/tests/test_icestorm.py
+++ b/tests/test_icestorm.py
@@ -87,16 +87,15 @@ def test_icestorm_nextpnr(make_edalize_test):
 
 def test_icestorm_invalid_pnr(make_edalize_test):
     name = "test_icestorm_0"
-    tf = make_edalize_test(
-        "icestorm",
-        test_name=name,
-        param_types=["vlogdefine", "vlogparam"],
-        tool_options={"pnr": "invalid"},
-        ref_dir="nextpnr",
-    )
 
     with pytest.raises(RuntimeError) as e:
-        tf.backend.configure()
+        tf = make_edalize_test(
+            "icestorm",
+            test_name=name,
+            param_types=["vlogdefine", "vlogparam"],
+            tool_options={"pnr": "invalid"},
+            ref_dir="nextpnr",
+        )
     assert (
         "Invalid pnr option 'invalid'. Valid values are 'next' for nextpnr or 'none' to only perform synthesis"
         in str(e.value)

--- a/tests/test_icestorm/minimal/edalize_yosys_procs.tcl
+++ b/tests/test_icestorm/minimal/edalize_yosys_procs.tcl
@@ -21,7 +21,7 @@ proc set_params {} {
 }
 
 proc synth {top} {
-synth_ice40 some yosys_synth_options -top $top
+synth_ice40  -top $top
 }
 
 set top top_module

--- a/tests/test_icestorm/nextpnr/edalize_yosys_procs.tcl
+++ b/tests/test_icestorm/nextpnr/edalize_yosys_procs.tcl
@@ -27,7 +27,7 @@ chparam -set vlogparam_int 42 top_module
 chparam -set vlogparam_str {"hello"} top_module}
 
 proc synth {top} {
-synth_ice40 some yosys_synth_options some yosys_synth_options -top $top
+synth_ice40 some yosys_synth_options -top $top
 }
 
 set top top_module


### PR DESCRIPTION
Before this change, there was no meaningful way to use flow options
because it was not possible to query or set tool options for tools
outside of the ones in the static FLOW list.

This patch separates the process of applying options into two steps.
A user can first use get_flow_options to get flow options and then
use get_tool_options with the preferred flow options set, to get
all tool options for a configured flow.

The redefinition of get_flow_options to only return flow options
(and not also tool options like previously) is an API break but will
hopefully not cause too much trouble.