### PR TITLE
add check to ensure -pvector option is used only when output_format is edif

### DIFF
--- a/edalize/yosys.py
+++ b/edalize/yosys.py
@@ -130,7 +130,9 @@ class Yosys(Edatool):
             "synth_options": " ".join(self.tool_options.get("yosys_synth_options", "")),
             "write_command": "write_" + output_format,
             "output_name": default_target,
-            "output_opts": "-pvector bra " if arch == "xilinx" else "",
+            "output_opts": "-pvector bra "
+            if (arch == "xilinx" and output_format == "edif")
+            else "",
             "yosys_template": template,
             "name": self.name,
         }

--- a/tests/test_symbiflow/nextpnr/fpga_interchange/edalize_yosys_template.tcl
+++ b/tests/test_symbiflow/nextpnr/fpga_interchange/edalize_yosys_template.tcl
@@ -13,4 +13,4 @@ verilog_defaults -pop
 
 synth $top
 
-write_json -pvector bra test_symbiflow_nextpnr_fpga_interchange_0.json
+write_json test_symbiflow_nextpnr_fpga_interchange_0.json

--- a/tests/test_symbiflow/nextpnr/xilinx/edalize_yosys_template.tcl
+++ b/tests/test_symbiflow/nextpnr/xilinx/edalize_yosys_template.tcl
@@ -13,4 +13,4 @@ verilog_defaults -pop
 
 synth $top
 
-write_json -pvector bra test_symbiflow_nextpnr_xilinx_0.json
+write_json test_symbiflow_nextpnr_xilinx_0.json


### PR DESCRIPTION
This pull request edits the Yosys command generator to ensure that the "-pvector bra" option is only included for edif files.


According to the Yosys docs, the "-pvector bra" option applies only to edif files i.e when the issued command is [write_edif](http://yosyshq.net/yosys/cmd_write_edif.html). Except I am missing something (entirely possible since I'm a bit new to this),  "-pvector bra" should not apply when the command is [write_json](http://yosyshq.net/yosys/cmd_write_json.html). In my experience, this made the write_json command fail.

The other changes are necessary implications of the first, and were generated by running the test suite with the  "GOLDEN_RUN" environment variable set.


