### PR TITLE
Set correct data types for board_device_index and speed

### DIFF
--- a/edalize/ise.py
+++ b/edalize/ise.py
@@ -86,12 +86,12 @@ quit
                     },
                     {
                         "name": "speed",
-                        "type": "String",
+                        "type": "Integer",
                         "desc": "FPGA speed grade (e.g. -2)",
                     },
                     {
                         "name": "board_device_index",
-                        "type": "String",
+                        "type": "Integer",
                         "desc": "Specifies the FPGA's device number in the JTAG chain, starting at 1",
                     },
                 ],

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -49,7 +49,7 @@ class Quartus(Edatool):
                     },
                     {
                         "name": "board_device_index",
-                        "type": "String",
+                        "type": "Integer",
                         "desc": "Specifies the FPGA's device number in the JTAG chain. The device index specifies the device where the flash programmer looks for the Nios® II JTAG debug module. JTAG devices are numbered relative to the JTAG chain, starting at 1. Use the tool `jtagconfig` to determine the index.",
                     },
                     {


### PR DESCRIPTION
A recent change in FuseSoC to better check data types revealed that some Edalize tool options were mistakenly set as strings instead of integers