### PR TITLE
Add support for user defined docker flags

### DIFF
--- a/scripts/el_docker
+++ b/scripts/el_docker
@@ -110,6 +110,7 @@ if [c for c in containers if c["tool"] == toolname]:
         logger.error("ERROR: Tool {} not found in container list.".format(toolname))
         exit(1)
 
+    extra = os.environ["EDALIZE_EXTRA_DOCKER_FLAGS"].split(" ")
     prefix = [
         "docker",
         "run",
@@ -117,6 +118,7 @@ if [c for c in containers if c["tool"] == toolname]:
         "-v",
         build_root + ":/src",
         #    '-e', dockerEnv,
+        ] + extra + [
         "-u",
         f"{os.getuid()}:{os.getgid()}",
         "-w",


### PR DESCRIPTION
Add support for supplying additional flags to docker such as mounting additional volumes.

This is useful e.g. if building via bazel and requesting a build using docker. The need stems from that el_docker is executed in the bazel sandbox. In the bazel sandbox all input sources only exists as symlinks. and docker won't have access to the real source files, unless the repo root is also added as a mounted volume.

This is oneway of enabling this.

Example project here:
https://github.com/solsjo/rules_edalize