### PR TITLE
Change Modelsim options order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__
 /.tox
 .vscode/
 build/
+dist/
+venv/
+.project
+.pydevproject

--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -44,7 +44,7 @@ EXTRA_OPTIONS ?= $(VSIM_OPTIONS) $(addprefix -g,$(PARAMETERS)) $(addprefix +,$(P
 all: work $(VPI_MODULES)
 
 run: work $(VPI_MODULES)
-	$(VSIM) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
+	$(VSIM) -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" $(TOPLEVEL)
 
 run-gui: work $(VPI_MODULES)
 	$(VSIM) -gui $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)

--- a/tests/test_modelsim/Makefile
+++ b/tests/test_modelsim/Makefile
@@ -33,7 +33,7 @@ EXTRA_OPTIONS ?= $(VSIM_OPTIONS) $(addprefix -g,$(PARAMETERS)) $(addprefix +,$(P
 all: work $(VPI_MODULES)
 
 run: work $(VPI_MODULES)
-	$(VSIM) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)
+	$(VSIM) -c $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) -do "run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit" $(TOPLEVEL)
 
 run-gui: work $(VPI_MODULES)
 	$(VSIM) -gui $(addprefix -pli ,$(VPI_MODULES)) $(EXTRA_OPTIONS) $(TOPLEVEL)

--- a/tests/test_modelsim/vsim2.cmd
+++ b/tests/test_modelsim/vsim2.cmd
@@ -1,1 +1,1 @@
--do run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit -c a few vsim_options -gvlogparam_bool=1 -gvlogparam_int=42 -gvlogparam_str=hello +plusarg_bool=1 +plusarg_int=42 +plusarg_str=hello top_module
+-c a few vsim_options -gvlogparam_bool=1 -gvlogparam_int=42 -gvlogparam_str=hello +plusarg_bool=1 +plusarg_int=42 +plusarg_str=hello -do run -all; quit -code [expr [coverage attribute -name TESTSTATUS -concise] >= 2 ? [coverage attribute -name TESTSTATUS -concise] : 0]; exit top_module


### PR DESCRIPTION
This is the followup PR from discussion in #345.

The place of the Modelsim EXTRA_OPTIONS has changed, so configuration scripts can be added before simulaton is running.