### PR TITLE
Vunit dependencies

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -400,10 +400,17 @@ class Edatool(object):
 
     def _get_fileset_files(self, force_slash=False):
         class File:
-            def __init__(self, name, file_type, logical_name):
+            def __init__(
+                self,
+                name,
+                file_type,
+                logical_name,
+                core=None,
+            ):
                 self.name = name
                 self.file_type = file_type
                 self.logical_name = logical_name
+                self.core = core
 
         incdirs = []
         src_files = []
@@ -414,7 +421,8 @@ class Edatool(object):
                     _name = _name.replace("\\", "/")
                 file_type = f.get("file_type", "")
                 logical_name = f.get("logical_name", "")
-                src_files.append(File(_name, file_type, logical_name))
+                core = f.get("core", None)
+                src_files.append(File(_name, file_type, logical_name, core))
         return (src_files, incdirs)
 
     def _param_value_str(self, param_value, str_quote_style="", bool_is_str=False):

--- a/edalize/templates/vunit/run.py.j2
+++ b/edalize/templates/vunit/run.py.j2
@@ -26,18 +26,45 @@ vu = runner.create()
 vu.add_{{ extlib }}()
 {% endfor %}
 
+files = {}
+
 {% for library, src_files in libraries.items() %}
 lib = vu.add_library("{{ library }}")
+files.update({
 {% for src_file in src_files if src_file|src_file_filter %}
 {% if (src_file|src_file_vhdl_standard_filter) %}
-lib.add_source_files("{{ src_file|src_file_filter }}", vhdl_standard="{{ src_file|src_file_vhdl_standard_filter }}")
+    "{{src_file|src_file_filter}}": lib.add_source_file("{{ src_file|src_file_filter }}", vhdl_standard="{{ src_file|src_file_vhdl_standard_filter }}"),
 {% else %}
-lib.add_source_files("{{ src_file|src_file_filter }}")
+    "{{src_file|src_file_filter}}": lib.add_source_file("{{ src_file|src_file_filter }}"),
 {% endif %}
 {% endfor %}
+})
+
 # Override this hook to customize the library, e.g. compile-flags etc.
 # This allows full access to vunit.ui.Library interface:
 runner.handle_library("{{ library }}", lib)
+
+{% endfor %}
+
+core_files = {
+{% for core, files in core_files.items() %}
+    "{{core}}": [
+{% for src_file in files %}
+        files["{{src_file|src_file_filter}}"],
+{% endfor %}
+    ],
+{% endfor %}
+}
+
+{% for core, dependencies in core_dependencies.items() %}
+for src_file in core_files["{{core}}"]:
+{% if dependencies %}
+{% for dependency in dependencies %}
+    src_file.add_dependency_on(core_files["{{dependency}}"])
+{% endfor %}
+{% else %}
+    pass
+{% endif %}
 
 {% endfor %}
 

--- a/edalize/vunit.py
+++ b/edalize/vunit.py
@@ -62,13 +62,12 @@ class Vunit(Edatool):
         # vunit does not allow empty library name or 'work', so we use `vunit_test_runner_lib`:
         libraries = OrderedDict()
 
+        core_files = {}
+        depend = {}
         for f in src_files:
             lib = f.logical_name if f.logical_name else "vunit_test_runner_lib"
-
-            if lib in libraries:
-                libraries[lib].append(f)
-            else:
-                libraries[lib] = [f]
+            libraries.setdefault(lib, []).append(f)
+            core_files.setdefault(f.core, []).append(f)
 
         escaped_name = self.name.replace(".", "_")
         add_libraries = self.tool_options.get("add_libraries", [])
@@ -79,6 +78,8 @@ class Vunit(Edatool):
                 "name": escaped_name,
                 "vunit_runner_path": self.get_vunit_runner_path(src_files),
                 "libraries": libraries,
+                "core_dependencies": self.edam["dependencies"],
+                "core_files": core_files,
                 "add_libraries": add_libraries,
                 "tool_options": self.tool_options,
             },


### PR DESCRIPTION
added dependency information for vunit

- added fields to edatool File class
  - "fileset": fileset which included the src file
  - "core": name of the core which included the src file
  - "depend": name list of core dependencies
- added core dependency and core file map to vunit jinja env
  - "depend": mapping of core name to core name of dependencies
  - "core_files": mapping of core name to src file objects
- reworked vunit template
  - save return value of added files added to libraries
  - generate mapping of core names to vunit file objects
  - specify core dependencies as dependencies between core files