### PR TITLE
-quiet option removed from vsim call

### DIFF
--- a/edalize/rivierapro.py
+++ b/edalize/rivierapro.py
@@ -216,5 +216,5 @@ class Rivierapro(Edatool):
                 "Environment variable ALDEC_PATH was not found. It should be set to Riviera Pro install path. Please source <Riviera Pro install path>/etc/setenv to set it"
             )
 
-        args = ["-c", "-quiet", "-do", "edalize_run.tcl"]
+        args = ["-c", "-do", "edalize_run.tcl"]
         self._run_tool("vsim", args)


### PR DESCRIPTION
-quiet option is invalid for standalone vsim command in Riviera-PRO