### PR TITLE
Libero Project TCL Updates

### DIFF
--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -13,10 +13,9 @@ build_design_hierarchy
 {% endif %}
 
 # Import HDL sources and constraints
-import_files \
-        {% for src_file in src_files if src_file|src_file_filter%}
-        {{src_file|src_file_filter}}{{cl}} \
-        {% endfor %}
+{% for src_file in src_files if src_file|src_file_filter%}
+import_files {{src_file|src_file_filter}}{{cl}}
+{% endfor %}
 
 # Import HDL sources on libraries (logical_names)
 {% for library in library_files.items() %}

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -65,16 +65,20 @@ organize_tool_files -tool {SYNTHESIZE} \
 {% endif %}
 
 # Configure Place and Route tool to use the project constraints
+{% set ns.CNST=false %}
 puts "----------------------- Place and Route Constraints ----------------------"
 {% for src_file in src_files if src_file|constraint_file_filter %}
+{% set ns.CNST=true %}
 puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
 {% endfor %}
 
+{% if ns.CNST %}
 organize_tool_files -tool {PLACEROUTE} \
         {% for src_file in src_files if src_file|constraint_file_filter %}
         -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
+{% endif %}
 
 {% if ns.SDC %}
 # Configure Verify Timing tool to use the project constraints

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -6,6 +6,11 @@ puts "----------------- Creating project {{name}} ------------------------------
 # Create a new project with device parameters
 new_project -location {{op}}{{prj_root}}{{cl}} -name {{name}} -project_description {} -hdl {{op}}{{tool_options.hdl}}{{cl}} -family {{op}}{{tool_options.family}}{{cl}} -die {{op}}{{tool_options.die}}{{cl}} -package {{op}}{{tool_options.package}}{{cl}} {% if tool_options.speed -%} -speed {{op}}{{tool_options.speed}}{{cl}}{{sp}}{%- endif %}{% if tool_options.dievoltage -%} -die_voltage {{op}}{{tool_options.dievoltage}}{{cl}}{{sp}}{%- endif %}{% if tool_options.range -%}-part_range {{op}}{{tool_options.range}}{{cl}}{{sp}}{%- endif %}{% if tool_options.defiostd -%} -adv_options {IO_DEFT_STD:{{tool_options.defiostd}}{{cl}}{% endif %}
 
+{% if incdirs %}
+# Set up the include directories
+set_global_include_path_order -paths "{% for incdir in incdirs %} [file normalize {{incdir}}] {% endfor %}"
+build_design_hierarchy
+{% endif %}
 
 # Import HDL sources and constraints
 import_files \

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -6,6 +6,7 @@ puts "----------------- Creating project {{name}} ------------------------------
 # Create a new project with device parameters
 new_project -location {{op}}{{prj_root}}{{cl}} -name {{name}} -project_description {} -hdl {{op}}{{tool_options.hdl}}{{cl}} -family {{op}}{{tool_options.family}}{{cl}} -die {{op}}{{tool_options.die}}{{cl}} -package {{op}}{{tool_options.package}}{{cl}} {% if tool_options.speed -%} -speed {{op}}{{tool_options.speed}}{{cl}}{{sp}}{%- endif %}{% if tool_options.dievoltage -%} -die_voltage {{op}}{{tool_options.dievoltage}}{{cl}}{{sp}}{%- endif %}{% if tool_options.range -%}-part_range {{op}}{{tool_options.range}}{{cl}}{{sp}}{%- endif %}{% if tool_options.defiostd -%} -adv_options {IO_DEFT_STD:{{tool_options.defiostd}}{{cl}}{% endif %}
 
+
 {% if incdirs %}
 # Set up the include directories
 set_global_include_path_order -paths "{% for incdir in incdirs %} [file normalize {{incdir}}] {% endfor %}"

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -25,16 +25,16 @@ import_files \
 
 {% endfor %}
 
-# Build design hierarchy and set the top module
-build_design_hierarchy
-puts "Setting top level module to: {{op}}{{toplevel}}::work{{cl}}"
-set_root -module {{op}}{{toplevel}}::work{{cl}}
-
 # Source user defined TCL scripts
 {% for src_file in src_files if src_file|tcl_file_filter%}
 puts "---------- Executing User TCL script: {{src_file|tcl_file_filter|replace("source", "")|trim}} ----------"
 {{src_file|tcl_file_filter}}
 {% endfor %}
+
+# Build design hierarchy and set the top module
+build_design_hierarchy
+puts "Setting top level module to: {{op}}{{toplevel}}::work{{cl}}"
+set_root -module {{op}}{{toplevel}}::work{{cl}}
 
 
 

--- a/tests/test_libero/libero-test-all-project.tcl
+++ b/tests/test_libero/libero-test-all-project.tcl
@@ -6,17 +6,20 @@ puts "----------------- Creating project libero-test-all -----------------------
 # Create a new project with device parameters
 new_project -location {./prj} -name libero-test-all -project_description {} -hdl {VHDL} -family {PolarFire} -die {MPF300TS_ES} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {EXT} -adv_options {IO_DEFT_STD:LVCMOS 1.8V}
 
+# Set up the include directories
+set_global_include_path_order -paths " [file normalize .] "
+build_design_hierarchy
+
 # Import HDL sources and constraints
-import_files \
-        -sdc {sdc_file} \
-        -hdl_source {sv_file.sv} \
-        -hdl_source {vlog_file.v} \
-        -hdl_source {vlog05_file.v} \
-        -hdl_source {vhdl_file.vhd} \
-        -hdl_source {vhdl2008_file} \
-        -hdl_source {another_sv_file.sv} \
-        -io_pdc {pdc_constraint_file.pdc} \
-        -fp_pdc {pdc_floorplan_constraint_file.pdc} \
+import_files -sdc {sdc_file}
+import_files -hdl_source {sv_file.sv}
+import_files -hdl_source {vlog_file.v}
+import_files -hdl_source {vlog05_file.v}
+import_files -hdl_source {vhdl_file.vhd}
+import_files -hdl_source {vhdl2008_file}
+import_files -hdl_source {another_sv_file.sv}
+import_files -io_pdc {pdc_constraint_file.pdc}
+import_files -fp_pdc {pdc_floorplan_constraint_file.pdc}
 
 # Import HDL sources on libraries (logical_names)
 import_files \
@@ -24,14 +27,14 @@ import_files \
         -hdl_source {vhdl_lfile} \
 
 
+# Source user defined TCL scripts
+puts "---------- Executing User TCL script: tcl_file.tcl ----------"
+source tcl_file.tcl
+
 # Build design hierarchy and set the top module
 build_design_hierarchy
 puts "Setting top level module to: {top_module::work}"
 set_root -module {top_module::work}
-
-# Source user defined TCL scripts
-puts "---------- Executing User TCL script: tcl_file.tcl ----------"
-source tcl_file.tcl
 
 
 

--- a/tests/test_libero/libero-test-project.tcl
+++ b/tests/test_libero/libero-test-project.tcl
@@ -6,17 +6,20 @@ puts "----------------- Creating project libero-test ---------------------------
 # Create a new project with device parameters
 new_project -location {./prj} -name libero-test -project_description {} -hdl {VERILOG} -family {PolarFire} -die {MPF300TS_ES} -package {FCG1152} -part_range {IND} 
 
+# Set up the include directories
+set_global_include_path_order -paths " [file normalize .] "
+build_design_hierarchy
+
 # Import HDL sources and constraints
-import_files \
-        -sdc {sdc_file} \
-        -hdl_source {sv_file.sv} \
-        -hdl_source {vlog_file.v} \
-        -hdl_source {vlog05_file.v} \
-        -hdl_source {vhdl_file.vhd} \
-        -hdl_source {vhdl2008_file} \
-        -hdl_source {another_sv_file.sv} \
-        -io_pdc {pdc_constraint_file.pdc} \
-        -fp_pdc {pdc_floorplan_constraint_file.pdc} \
+import_files -sdc {sdc_file}
+import_files -hdl_source {sv_file.sv}
+import_files -hdl_source {vlog_file.v}
+import_files -hdl_source {vlog05_file.v}
+import_files -hdl_source {vhdl_file.vhd}
+import_files -hdl_source {vhdl2008_file}
+import_files -hdl_source {another_sv_file.sv}
+import_files -io_pdc {pdc_constraint_file.pdc}
+import_files -fp_pdc {pdc_floorplan_constraint_file.pdc}
 
 # Import HDL sources on libraries (logical_names)
 import_files \
@@ -24,14 +27,14 @@ import_files \
         -hdl_source {vhdl_lfile} \
 
 
+# Source user defined TCL scripts
+puts "---------- Executing User TCL script: tcl_file.tcl ----------"
+source tcl_file.tcl
+
 # Build design hierarchy and set the top module
 build_design_hierarchy
 puts "Setting top level module to: {top_module::work}"
 set_root -module {top_module::work}
-
-# Source user defined TCL scripts
-puts "---------- Executing User TCL script: tcl_file.tcl ----------"
-source tcl_file.tcl
 
 
 


### PR DESCRIPTION
I've been working on incorporating FuseSoC/Edalize into an existing project, and I made a few updates to the Libero project template to get it to build.

1. Add include directories to Libero project
2. Set root after running user TCL scripts (this allows a SmartDesign to be used as the root)
3. Skip organize_tool_files when no constraints are present (avoids a Libero error since -file is required)