### PR TITLE
Add support for Libero netlist constraints

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -161,6 +161,7 @@ class Edatool(object):
 
         self.hooks = edam.get("hooks", {})
         self.parameters = edam.get("parameters", {})
+        self.export_files = edam.get("export_files", True)
 
         self.work_root = work_root
         self.env = os.environ.copy()

--- a/edalize/icestorm.py
+++ b/edalize/icestorm.py
@@ -61,5 +61,8 @@ class Icestorm(Edatool):
     def build_pre(self):
         pass
 
+    def build_main(self):
+        self.icestorm.build()
+
     def build_post(self):
         pass

--- a/edalize/libero.py
+++ b/edalize/libero.py
@@ -95,6 +95,12 @@ class Libero(Edatool):
         self._check_mandatory_options()
         (src_files, incdirs) = self._get_fileset_files(force_slash=True)
         self.jinja_env.filters["src_file_filter"] = self.src_file_filter
+        self.jinja_env.filters[
+            "syn_constraint_file_filter"
+        ] = self.syn_constraint_file_filter
+        self.jinja_env.filters[
+            "pnr_constraint_file_filter"
+        ] = self.pnr_constraint_file_filter
         self.jinja_env.filters["constraint_file_filter"] = self.constraint_file_filter
         self.jinja_env.filters["tcl_file_filter"] = self.tcl_file_filter
 
@@ -168,6 +174,8 @@ class Libero(Edatool):
             "PDC": "-io_pdc {",
             "SDC": "-sdc {",
             "FPPDC": "-fp_pdc {",
+            "FDC": "-net_fdc {",
+            "NDC": "-ndc {",
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:
@@ -186,11 +194,37 @@ class Libero(Edatool):
             return file_types[_file_type] + f.name
         return ""
 
+    def syn_constraint_file_filter(self, f):
+        file_types = {
+            "SDC": "constraint/",
+            "FDC": "constraint/",
+            "NDC": "constraint/",
+        }
+        _file_type = f.file_type.split("-")[0]
+        if _file_type in file_types:
+            filename = f.name.split("/")[-1]
+            return file_types[_file_type] + filename
+        return ""
+
+    def pnr_constraint_file_filter(self, f):
+        file_types = {
+            "PDC": "constraint/io/",
+            "SDC": "constraint/",
+            "FPPDC": "constraint/fp/",
+        }
+        _file_type = f.file_type.split("-")[0]
+        if _file_type in file_types:
+            filename = f.name.split("/")[-1]
+            return file_types[_file_type] + filename
+        return ""
+
     def constraint_file_filter(self, f, type="ALL"):
         file_types = {
             "PDC": "constraint/io/",
             "SDC": "constraint/",
             "FPPDC": "constraint/fp/",
+            "FDC": "constraint/",
+            "NDC": "constraint/",
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:

--- a/edalize/libero.py
+++ b/edalize/libero.py
@@ -255,7 +255,7 @@ class Libero(Edatool):
             self._run_tool("libero", ["SCRIPT:" + escaped_name + "-run.tcl"])
         else:
             filePath = os.path.join(
-                Path(self.work_root).relative_to(os.getcwd()), escaped_name + "-run.tcl"
+                os.path.relpath(self.work_root), escaped_name + "-run.tcl"
             )
             logger.warn(
                 'Libero not found on path, execute manually the script "'

--- a/edalize/libero.py
+++ b/edalize/libero.py
@@ -130,6 +130,7 @@ class Libero(Edatool):
             "op": "{",
             "cl": "}",
             "sp": " ",
+            "export_files": self.export_files,
         }
 
         # Set preferred HDL language based on file type amount if not user defined.
@@ -202,8 +203,11 @@ class Libero(Edatool):
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:
-            filename = f.name.split("/")[-1]
-            return file_types[_file_type] + filename
+            if self.export_files:
+                filename = f.name.split("/")[-1]
+                return file_types[_file_type] + filename
+            else:
+                return f.name
         return ""
 
     def pnr_constraint_file_filter(self, f):
@@ -214,8 +218,11 @@ class Libero(Edatool):
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:
-            filename = f.name.split("/")[-1]
-            return file_types[_file_type] + filename
+            if self.export_files:
+                filename = f.name.split("/")[-1]
+                return file_types[_file_type] + filename
+            else:
+                return f.name
         return ""
 
     def constraint_file_filter(self, f, type="ALL"):
@@ -228,11 +235,17 @@ class Libero(Edatool):
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:
-            filename = f.name.split("/")[-1]
-            if type == "ALL":
-                return file_types[_file_type] + filename
-            elif _file_type == type:
-                return file_types[_file_type] + filename
+            if self.export_files:
+                filename = f.name.split("/")[-1]
+                if type == "ALL":
+                    return file_types[_file_type] + filename
+                elif _file_type == type:
+                    return file_types[_file_type] + filename
+            else:
+                if type == "ALL":
+                    return f.name
+                elif _file_type == type:
+                    return f.name
         return ""
 
     def build_main(self):

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -53,47 +53,47 @@ puts "Configured Synthesize tool to include dirs:"
 puts "- ../../{{dir}}"
 {% endfor -%}{% endif %}
 
-{% set ns = namespace(SDC=false) %}{# If SDC files are present #}
-{% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
-{% set ns.SDC=true %}
 puts "----------------------- Synthesize Constraints ---------------------------"
-puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
+{% set ns = namespace(SYN=false) %}{# If synthesis constraints are present #}
+{% for src_file in src_files if src_file|syn_constraint_file_filter %}
+{% set ns.SYN=true %}
+puts "File: {{prj_root}}/{{src_file|syn_constraint_file_filter}}"
 {% endfor %}
 
-{%- if ns.SDC %}
+{%- if ns.SYN %}
 # Configure Synthesize tool to use the project constraints
 organize_tool_files -tool {SYNTHESIZE} \
-        {% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
-        -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
+        {% for src_file in src_files if src_file|syn_constraint_file_filter %}
+        -file {{op}}{{prj_root}}/{{src_file|syn_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
 
 # Configure Place and Route tool to use the project constraints
-{% set ns.CNST=false %}
 puts "----------------------- Place and Route Constraints ----------------------"
-{% for src_file in src_files if src_file|constraint_file_filter %}
-{% set ns.CNST=true %}
-puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
+{% set ns.PNR=false %}
+{% for src_file in src_files if src_file|pnr_constraint_file_filter %}
+{% set ns.PNR=true %}
+puts "File: {{prj_root}}/{{src_file|pnr_constraint_file_filter}}"
 {% endfor %}
 
-{% if ns.CNST %}
+{% if ns.PNR %}
 organize_tool_files -tool {PLACEROUTE} \
-        {% for src_file in src_files if src_file|constraint_file_filter %}
-        -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
+        {% for src_file in src_files if src_file|pnr_constraint_file_filter %}
+        -file {{op}}{{prj_root}}/{{src_file|pnr_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
 
-{% if ns.SDC %}
 # Configure Verify Timing tool to use the project constraints
-{% endif %}
-{%- for src_file in src_files if src_file|constraint_file_filter("SDC") %}
 puts "----------------------- Verify Timings Constraints -----------------------"
+{% set ns.TIM=false %}
+{%- for src_file in src_files if src_file|constraint_file_filter("SDC") %}
+{% set ns.TIM=true %}
 puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
 {% endfor %}
 
-{%- if ns.SDC %}
+{%- if ns.TIM %}
 organize_tool_files -tool {VERIFYTIMING} \
         {% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
         -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -9,14 +9,18 @@ new_project -location {{op}}{{prj_root}}{{cl}} -name {{name}} -project_descripti
 
 {% if incdirs %}
 # Set up the include directories
-set_global_include_path_order -paths "{% for incdir in incdirs %} [file normalize {{incdir}}] {% endfor %}"
+set_global_include_path_order -paths "{% for incdir in incdirs %} {{incdir}} {% endfor %}"
 build_design_hierarchy
 {% endif %}
 
 # Import HDL sources and constraints
-{% for src_file in src_files if src_file|src_file_filter%}
-import_files {{src_file|src_file_filter}}{{cl}}
-{% endfor %}
+{% if export_files %}
+set libero_export_files 1
+import_files {% for src_file in src_files if src_file|src_file_filter%} {{src_file|src_file_filter}}{{cl}} {% endfor %}
+{% else %}
+set libero_export_files 0
+create_links {% for src_file in src_files if src_file|src_file_filter%} {{src_file|src_file_filter}}{{cl}} {% endfor %}
+{% endif %}
 
 # Import HDL sources on libraries (logical_names)
 {% for library in library_files.items() %}
@@ -57,14 +61,14 @@ puts "----------------------- Synthesize Constraints ---------------------------
 {% set ns = namespace(SYN=false) %}{# If synthesis constraints are present #}
 {% for src_file in src_files if src_file|syn_constraint_file_filter %}
 {% set ns.SYN=true %}
-puts "File: {{prj_root}}/{{src_file|syn_constraint_file_filter}}"
+puts "File: {% if export_files %}{{prj_root}}/{% endif %}{{src_file|syn_constraint_file_filter}}"
 {% endfor %}
 
 {%- if ns.SYN %}
 # Configure Synthesize tool to use the project constraints
 organize_tool_files -tool {SYNTHESIZE} \
         {% for src_file in src_files if src_file|syn_constraint_file_filter %}
-        -file {{op}}{{prj_root}}/{{src_file|syn_constraint_file_filter}}{{cl}} \
+        -file {{op}}{% if export_files %}{{prj_root}}/{% endif %}{{src_file|syn_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
@@ -74,13 +78,13 @@ puts "----------------------- Place and Route Constraints ----------------------
 {% set ns.PNR=false %}
 {% for src_file in src_files if src_file|pnr_constraint_file_filter %}
 {% set ns.PNR=true %}
-puts "File: {{prj_root}}/{{src_file|pnr_constraint_file_filter}}"
+puts "File: {% if export_files %}{{prj_root}}/{% endif %}{{src_file|pnr_constraint_file_filter}}"
 {% endfor %}
 
 {% if ns.PNR %}
 organize_tool_files -tool {PLACEROUTE} \
         {% for src_file in src_files if src_file|pnr_constraint_file_filter %}
-        -file {{op}}{{prj_root}}/{{src_file|pnr_constraint_file_filter}}{{cl}} \
+        -file {{op}}{% if export_files %}{{prj_root}}/{% endif %}{{src_file|pnr_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
@@ -90,13 +94,13 @@ puts "----------------------- Verify Timings Constraints -----------------------
 {% set ns.TIM=false %}
 {%- for src_file in src_files if src_file|constraint_file_filter("SDC") %}
 {% set ns.TIM=true %}
-puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
+puts "File: {% if export_files %}{{prj_root}}/{% endif %}{{src_file|constraint_file_filter}}"
 {% endfor %}
 
 {%- if ns.TIM %}
 organize_tool_files -tool {VERIFYTIMING} \
         {% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
-        -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
+        -file {{op}}{% if export_files %}{{prj_root}}/{% endif %}{{src_file|constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}

--- a/tests/test_libero/libero-test-all-project.tcl
+++ b/tests/test_libero/libero-test-all-project.tcl
@@ -7,20 +7,12 @@ puts "----------------- Creating project libero-test-all -----------------------
 new_project -location {./prj} -name libero-test-all -project_description {} -hdl {VHDL} -family {PolarFire} -die {MPF300TS_ES} -package {FCG1152} -speed {-1} -die_voltage {1.0} -part_range {EXT} -adv_options {IO_DEFT_STD:LVCMOS 1.8V}
 
 # Set up the include directories
-set_global_include_path_order -paths " [file normalize .] "
+set_global_include_path_order -paths " . "
 build_design_hierarchy
 
 # Import HDL sources and constraints
-import_files -sdc {sdc_file}
-import_files -hdl_source {sv_file.sv}
-import_files -hdl_source {vlog_file.v}
-import_files -hdl_source {vlog05_file.v}
-import_files -hdl_source {vhdl_file.vhd}
-import_files -hdl_source {vhdl2008_file}
-import_files -hdl_source {another_sv_file.sv}
-import_files -io_pdc {pdc_constraint_file.pdc}
-import_files -fp_pdc {pdc_floorplan_constraint_file.pdc}
-
+set libero_export_files 1
+import_files  -sdc {sdc_file}  -hdl_source {sv_file.sv}  -hdl_source {vlog_file.v}  -hdl_source {vlog05_file.v}  -hdl_source {vhdl_file.vhd}  -hdl_source {vhdl2008_file}  -hdl_source {another_sv_file.sv}  -io_pdc {pdc_constraint_file.pdc}  -fp_pdc {pdc_floorplan_constraint_file.pdc} 
 # Import HDL sources on libraries (logical_names)
 import_files \
         -library {libx} \

--- a/tests/test_libero/libero-test-project.tcl
+++ b/tests/test_libero/libero-test-project.tcl
@@ -7,20 +7,12 @@ puts "----------------- Creating project libero-test ---------------------------
 new_project -location {./prj} -name libero-test -project_description {} -hdl {VERILOG} -family {PolarFire} -die {MPF300TS_ES} -package {FCG1152} -part_range {IND} 
 
 # Set up the include directories
-set_global_include_path_order -paths " [file normalize .] "
+set_global_include_path_order -paths " . "
 build_design_hierarchy
 
 # Import HDL sources and constraints
-import_files -sdc {sdc_file}
-import_files -hdl_source {sv_file.sv}
-import_files -hdl_source {vlog_file.v}
-import_files -hdl_source {vlog05_file.v}
-import_files -hdl_source {vhdl_file.vhd}
-import_files -hdl_source {vhdl2008_file}
-import_files -hdl_source {another_sv_file.sv}
-import_files -io_pdc {pdc_constraint_file.pdc}
-import_files -fp_pdc {pdc_floorplan_constraint_file.pdc}
-
+set libero_export_files 1
+import_files  -sdc {sdc_file}  -hdl_source {sv_file.sv}  -hdl_source {vlog_file.v}  -hdl_source {vlog05_file.v}  -hdl_source {vhdl_file.vhd}  -hdl_source {vhdl2008_file}  -hdl_source {another_sv_file.sv}  -io_pdc {pdc_constraint_file.pdc}  -fp_pdc {pdc_floorplan_constraint_file.pdc} 
 # Import HDL sources on libraries (logical_names)
 import_files \
         -library {libx} \

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ envlist = py3
 deps = pytest
 extras = reporting
 commands = pytest {posargs}
+passenv = GOLDEN_RUN


### PR DESCRIPTION
Libero has two types of netlist constraints files that are synthesis only, so they didn't work with the existing setup. Adding specific filters for synthesis and place/route simplified the changes needed to the template. I also added GOLDEN_RUN to be passed through to tox.