### PR TITLE
Make Symbiflow use systemVerilogSource files

### DIFF
--- a/edalize/symbiflow.py
+++ b/edalize/symbiflow.py
@@ -257,6 +257,8 @@ endif
         for f in src_files:
             if f.file_type in ["verilogSource"]:
                 file_list.append(f.name)
+            if f.file_type in ["systemVerilogSource"]:
+                file_list.append(f.name)
             if f.file_type in ["SDC"]:
                 timing_constraints.append(f.name)
             if f.file_type in ["PCF"]:


### PR DESCRIPTION
Had to make my .sv files be listed as "verilogSource" as a workaround.