### PR TITLE
Add a --pgm tool option to stop build stage from automatically programming

### DIFF
--- a/edalize/ise.py
+++ b/edalize/ise.py
@@ -94,6 +94,11 @@ quit
                         "type": "Integer",
                         "desc": "Specifies the FPGA's device number in the JTAG chain, starting at 1",
                     },
+                    {
+                        "name": "pgm",
+                        "type": "String",
+                        "desc": "Programming tool. Default is 'none', set to 'ise' to program the FPGA in the run stage."
+                    },
                 ],
             }
 
@@ -188,6 +193,8 @@ quit
         tcl_file.close()
 
     def run_main(self):
+        if ("pgm" not in self.tool_options) or (self.tool_options["pgm"] != "ise"):
+            return
         pgm_file_name = os.path.join(self.work_root, self.name + ".pgm")
         self._write_pgm_file(pgm_file_name)
         self._run_tool("impact", ["-batch", pgm_file_name])

--- a/edalize/ise.py
+++ b/edalize/ise.py
@@ -97,7 +97,7 @@ quit
                     {
                         "name": "pgm",
                         "type": "String",
-                        "desc": "Programming tool. Default is 'none', set to 'ise' to program the FPGA in the run stage."
+                        "desc": "Programming tool. Default is 'none', set to 'ise' to program the FPGA in the run stage.",
                     },
                 ],
             }

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -60,7 +60,7 @@ class Quartus(Edatool):
                     {
                         "name": "pgm",
                         "type": "String",
-                        "desc": "Programming tool. Default is 'none', set to 'quartus' to program the FPGA in the run stage."
+                        "desc": "Programming tool. Default is 'none', set to 'quartus' to program the FPGA in the run stage.",
                     },
                 ],
                 "lists": [

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -57,6 +57,11 @@ class Quartus(Edatool):
                         "type": "String",
                         "desc": "P&R tool. Allowed values are quartus (default), dse (to run Design Space Explorer) and none (to just run synthesis)",
                     },
+                    {
+                        "name": "pgm",
+                        "type": "String",
+                        "desc": "Programming tool. Default is 'none', set to 'quartus' to program the FPGA in the run stage."
+                    },
                 ],
                 "lists": [
                     {
@@ -275,13 +280,8 @@ class Quartus(Edatool):
         args += ["-o"]
         args += ["p;" + self.name.replace(".", "_") + ".sof"]
 
-        if "pnr" in self.tool_options:
-            if self.tool_options["pnr"] == "quartus":
-                pass
-            elif self.tool_options["pnr"] == "dse":
-                return
-            elif self.tool_options["pnr"] == "none":
-                return
+        if ("pgm" not in self.tool_options) or (self.tool_options["pgm"] != "quartus"):
+            return
 
         if "board_device_index" in self.tool_options:
             args[-1] += "@" + self.tool_options["board_device_index"]

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -64,7 +64,7 @@ class Vivado(Edatool):
                     {
                         "name": "pgm",
                         "type": "String",
-                        "desc": "Programming tool. Default is none, set to 'vivado' to program the FPGA in the run stage."
+                        "desc": "Programming tool. Default is none, set to 'vivado' to program the FPGA in the run stage.",
                     },
                     {
                         "name": "jobs",

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -62,6 +62,11 @@ class Vivado(Edatool):
                         "desc": "P&R tool. Allowed values are vivado (default) and none (to just run synthesis)",
                     },
                     {
+                        "name": "pgm",
+                        "type": "String",
+                        "desc": "Programming tool. Default is none, set to 'vivado' to program the FPGA in the run stage."
+                    },
+                    {
                         "name": "jobs",
                         "type": "Integer",
                         "desc": "Number of jobs. Useful for parallelizing OOC (Out Of Context) syntheses.",
@@ -115,11 +120,8 @@ class Vivado(Edatool):
         correct FPGA board and then downloads the bitstream. The tcl script is then
         executed in Vivado's batch mode.
         """
-        if "pnr" in self.tool_options:
-            if self.tool_options["pnr"] == "vivado":
-                pass
-            elif self.tool_options["pnr"] == "none":
-                return
+        if ("pgm" not in self.tool_options) or (self.tool_options["pgm"] != "vivado"):
+            return
 
         self._run_tool("make", ["pgm"])
 


### PR DESCRIPTION
Add a `--pgm` argument to separate place & route from programming in build stages using relevant tools (Vivado, Quartus, ISE). By default these won't attempt to program a device (which can quite easily crash servers unless a number of other options are also configured), but setting `--pgm=<applicable tool>` will allow it to do so.