### PR TITLE
Fix PR tests for python >3.8

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -99,7 +99,7 @@ def subprocess_run_3_9(
     return subprocess.CompletedProcess(process.args, retcode, stdout, stderr)
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     run = subprocess_run_3_9
 else:
     run = subprocess.run

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py3
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    pandas==2.0.3
 extras = reporting
 commands = pytest {posargs}
+passenv = GOLDEN_RUN

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py3
 [testenv]
 deps =
     pytest
-    pandas==2.0.3
+    pandas<=2.0.3
 extras = reporting
 commands = pytest {posargs}
 passenv = GOLDEN_RUN


### PR DESCRIPTION
There seems to be a bug with newer versions of pandas that prevents kwargs from being passed through the apply function (specifically passing errors='ignore' to to_numeric in edalize/vivado_reporting.py). Pinning pandas to v2.0.3 appears to have fixed the issue for now.

I also added GOLDEN_RUN to pass through to tox.