### PR TITLE
Add support for Libero netlist constraints

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -99,7 +99,7 @@ def subprocess_run_3_9(
     return subprocess.CompletedProcess(process.args, retcode, stdout, stderr)
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     run = subprocess_run_3_9
 else:
     run = subprocess.run

--- a/edalize/libero.py
+++ b/edalize/libero.py
@@ -95,6 +95,12 @@ class Libero(Edatool):
         self._check_mandatory_options()
         (src_files, incdirs) = self._get_fileset_files(force_slash=True)
         self.jinja_env.filters["src_file_filter"] = self.src_file_filter
+        self.jinja_env.filters[
+            "syn_constraint_file_filter"
+        ] = self.syn_constraint_file_filter
+        self.jinja_env.filters[
+            "pnr_constraint_file_filter"
+        ] = self.pnr_constraint_file_filter
         self.jinja_env.filters["constraint_file_filter"] = self.constraint_file_filter
         self.jinja_env.filters["tcl_file_filter"] = self.tcl_file_filter
 
@@ -168,6 +174,8 @@ class Libero(Edatool):
             "PDC": "-io_pdc {",
             "SDC": "-sdc {",
             "FPPDC": "-fp_pdc {",
+            "FDC": "-net_fdc {",
+            "NDC": "-ndc {",
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:
@@ -186,11 +194,37 @@ class Libero(Edatool):
             return file_types[_file_type] + f.name
         return ""
 
+    def syn_constraint_file_filter(self, f):
+        file_types = {
+            "SDC": "constraint/",
+            "FDC": "constraint/",
+            "NDC": "constraint/",
+        }
+        _file_type = f.file_type.split("-")[0]
+        if _file_type in file_types:
+            filename = f.name.split("/")[-1]
+            return file_types[_file_type] + filename
+        return ""
+
+    def pnr_constraint_file_filter(self, f):
+        file_types = {
+            "PDC": "constraint/io/",
+            "SDC": "constraint/",
+            "FPPDC": "constraint/fp/",
+        }
+        _file_type = f.file_type.split("-")[0]
+        if _file_type in file_types:
+            filename = f.name.split("/")[-1]
+            return file_types[_file_type] + filename
+        return ""
+
     def constraint_file_filter(self, f, type="ALL"):
         file_types = {
             "PDC": "constraint/io/",
             "SDC": "constraint/",
             "FPPDC": "constraint/fp/",
+            "FDC": "constraint/",
+            "NDC": "constraint/",
         }
         _file_type = f.file_type.split("-")[0]
         if _file_type in file_types:

--- a/edalize/templates/libero/libero-project.tcl.j2
+++ b/edalize/templates/libero/libero-project.tcl.j2
@@ -53,47 +53,47 @@ puts "Configured Synthesize tool to include dirs:"
 puts "- ../../{{dir}}"
 {% endfor -%}{% endif %}
 
-{% set ns = namespace(SDC=false) %}{# If SDC files are present #}
-{% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
-{% set ns.SDC=true %}
 puts "----------------------- Synthesize Constraints ---------------------------"
-puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
+{% set ns = namespace(SYN=false) %}{# If synthesis constraints are present #}
+{% for src_file in src_files if src_file|syn_constraint_file_filter %}
+{% set ns.SYN=true %}
+puts "File: {{prj_root}}/{{src_file|syn_constraint_file_filter}}"
 {% endfor %}
 
-{%- if ns.SDC %}
+{%- if ns.SYN %}
 # Configure Synthesize tool to use the project constraints
 organize_tool_files -tool {SYNTHESIZE} \
-        {% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
-        -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
+        {% for src_file in src_files if src_file|syn_constraint_file_filter %}
+        -file {{op}}{{prj_root}}/{{src_file|syn_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
 
 # Configure Place and Route tool to use the project constraints
-{% set ns.CNST=false %}
 puts "----------------------- Place and Route Constraints ----------------------"
-{% for src_file in src_files if src_file|constraint_file_filter %}
-{% set ns.CNST=true %}
-puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
+{% set ns.PNR=false %}
+{% for src_file in src_files if src_file|pnr_constraint_file_filter %}
+{% set ns.PNR=true %}
+puts "File: {{prj_root}}/{{src_file|pnr_constraint_file_filter}}"
 {% endfor %}
 
-{% if ns.CNST %}
+{% if ns.PNR %}
 organize_tool_files -tool {PLACEROUTE} \
-        {% for src_file in src_files if src_file|constraint_file_filter %}
-        -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \
+        {% for src_file in src_files if src_file|pnr_constraint_file_filter %}
+        -file {{op}}{{prj_root}}/{{src_file|pnr_constraint_file_filter}}{{cl}} \
         {% endfor %}
         -module {{op}}{{toplevel}}::work{{cl}} -input_type {constraint}
 {% endif %}
 
-{% if ns.SDC %}
 # Configure Verify Timing tool to use the project constraints
-{% endif %}
-{%- for src_file in src_files if src_file|constraint_file_filter("SDC") %}
 puts "----------------------- Verify Timings Constraints -----------------------"
+{% set ns.TIM=false %}
+{%- for src_file in src_files if src_file|constraint_file_filter("SDC") %}
+{% set ns.TIM=true %}
 puts "File: {{prj_root}}/{{src_file|constraint_file_filter}}"
 {% endfor %}
 
-{%- if ns.SDC %}
+{%- if ns.TIM %}
 organize_tool_files -tool {VERIFYTIMING} \
         {% for src_file in src_files if src_file|constraint_file_filter("SDC") %}
         -file {{op}}{{prj_root}}/{{src_file|constraint_file_filter}}{{cl}} \

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py3
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    pandas==2.0.3
 extras = reporting
 commands = pytest {posargs}
+passenv = GOLDEN_RUN

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py3
 [testenv]
 deps =
     pytest
-    pandas==2.0.3
+    pandas<=2.0.3
 extras = reporting
 commands = pytest {posargs}
 passenv = GOLDEN_RUN


### PR DESCRIPTION
Libero has two types of netlist constraints files that are synthesis
only, so they didn't work with the existing setup. Adding specific
filters for synthesis and place/route simplified the changes needed to
the template.