### PR TITLE
Support SystemVerilog sources with radiant tool

### DIFF
--- a/edalize/radiant.py
+++ b/edalize/radiant.py
@@ -110,6 +110,7 @@ prj_close
 
         file_types = {
             "verilogSource": "prj_add_source ",
+            "systemVerilogSource": "prj_add_source ",
             "vhdlSource": "prj_add_source ",
             "PDC": "prj_add_source ",
         }

--- a/tests/test_radiant/test_radiant_0.tcl
+++ b/tests/test_radiant/test_radiant_0.tcl
@@ -5,12 +5,14 @@ prj_set_impl_opt {include path} {.}
 prj_set_impl_opt HDL_PARAM {generic_bool=True;generic_int=42;generic_str=hello}
 prj_set_impl_opt HDL_PARAM {vlogparam_bool=1;vlogparam_int=42;vlogparam_str="hello"}
 prj_set_impl_opt VERILOG_DIRECTIVES {vlogdefine_bool=True;vlogdefine_int=42;vlogdefine_str=hello}
+prj_add_source sv_file.sv -work work
 source tcl_file.tcl
 prj_add_source vlog_file.v -work work
 prj_add_source vlog05_file.v -work work
 prj_add_source vhdl_file.vhd -work work
 prj_add_source vhdl_lfile -work libx
 prj_add_source vhdl2008_file -work work
+prj_add_source another_sv_file.sv -work work
 prj_add_source pdc_constraint_file.pdc -work work
 prj_save
 prj_close


### PR DESCRIPTION
This PR adds support for systemVerilogSource file types with the LatticeSemi Radiant tool. Radiant doesn't require any additional options when reading Verilog vs SystemVerilog sources. 