### PR TITLE
Add cocotb verilator flow_tool option

### DIFF
--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -42,7 +42,7 @@ class Sim(Generic):
                     ["--vpi",
                      "--public-flat-rw --prefix Vtop",
                      "-LDFLAGS \"-Wl,-rpath,`cocotb-config --lib-dir` -L`cocotb-config --lib-dir` -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils\""
-                    ],
+                     ],
                 ),
             }
             (opt, val) = cocotb_options[tool]

--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -43,8 +43,7 @@ class Sim(Generic):
                 "verilator": (
                     "verilator_options",
                     ["--vpi",
-                     "--top top",
-                     "--public-flat-rw",
+                     "--public-flat-rw --prefix Vtop",
                      "-LDFLAGS \"-Wl,-rpath,`cocotb-config --lib-dir` -L`cocotb-config --lib-dir` \
                      -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils\"",
                     f"{share_dir}"

--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from edalize.flows.generic import Generic
+import os
 
 
 class Sim(Generic):
@@ -23,6 +24,8 @@ class Sim(Generic):
     def configure_tools(self, flow):
         if self.flow_options.get("cocotb_module"):
             tool = self.flow_options.get("tool")
+            share_dir = os.popen("cocotb-config --share").read().rstrip() \
+            + "/lib/verilator/verilator.cpp"
             cocotb_options = {
                 "icarus": (
                     "vvp_options",
@@ -36,6 +39,16 @@ class Sim(Generic):
                 "modelsim": (
                     "vsim_options",
                     ["-pli", "`cocotb-config --lib-name-path vpi questa`"],
+                ),
+                "verilator": (
+                    "verilator_options",
+                    ["--vpi",
+                     "--top top",
+                     "--public-flat-rw",
+                     "-LDFLAGS \"-Wl,-rpath,`cocotb-config --lib-dir` -L`cocotb-config --lib-dir` \
+                     -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils\"",
+                    f"{share_dir}"
+                    ],
                 ),
             }
             (opt, val) = cocotb_options[tool]

--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from edalize.flows.generic import Generic
-import os
 
 
 class Sim(Generic):

--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -24,8 +24,6 @@ class Sim(Generic):
     def configure_tools(self, flow):
         if self.flow_options.get("cocotb_module"):
             tool = self.flow_options.get("tool")
-            share_dir = os.popen("cocotb-config --share").read().rstrip() \
-            + "/lib/verilator/verilator.cpp"
             cocotb_options = {
                 "icarus": (
                     "vvp_options",
@@ -44,9 +42,7 @@ class Sim(Generic):
                     "verilator_options",
                     ["--vpi",
                      "--public-flat-rw --prefix Vtop",
-                     "-LDFLAGS \"-Wl,-rpath,`cocotb-config --lib-dir` -L`cocotb-config --lib-dir` \
-                     -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils\"",
-                    f"{share_dir}"
+                     "-LDFLAGS \"-Wl,-rpath,`cocotb-config --lib-dir` -L`cocotb-config --lib-dir` -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils\""
                     ],
                 ),
             }

--- a/edalize/tools/verilator.py
+++ b/edalize/tools/verilator.py
@@ -61,7 +61,8 @@ class Verilator(Edatool):
 
         if mode not in EdalizeVerilator.modes:
             _s = "Illegal verilator mode {}. Allowed values are {}"
-            raise RuntimeError(_s.format(mode, ", ".join(EdalizeVerilator.modes)))
+            raise RuntimeError(
+                _s.format(mode, ", ".join(EdalizeVerilator.modes)))
         vc.append("--" + mode)
 
         vc += self.tool_options.get("verilator_options", [])
@@ -117,15 +118,16 @@ class Verilator(Edatool):
 
         for k, v in self.vlogparam.items():
             vc.append(
-                "-G{}={}".format(k, self._param_value_str(v, str_quote_style='\\"'))
+                "-G{}={}".format(k, self._param_value_str(v,
+                                 str_quote_style='\\"'))
             )
         for k, v in self.vlogdefine.items():
             vc.append("-D{}={}".format(k, self._param_value_str(v)))
 
         self.vc = vc
         if self.edam["flow_options"].get("cocotb_module"):
-        	self.toplevel = "top"
-        	verilator_file += " `cocotb-config --share`/lib/verilator/verilator.cpp"
+            self.toplevel = "top"
+            verilator_file += " `cocotb-config --share`/lib/verilator/verilator.cpp"
         mk_file = f"V{self.toplevel}.mk"
         exe_file = f"V{self.toplevel}"
         commands = EdaCommands()
@@ -145,7 +147,8 @@ class Verilator(Edatool):
             commands.set_default_target(mk_file)
         else:
             commands.add(
-                ["make", "-f", mk_file] + self.tool_options.get("make_options", []),
+                ["make", "-f", mk_file] +
+                self.tool_options.get("make_options", []),
                 [exe_file],
                 [mk_file] + opt_c_files,
             )

--- a/edalize/tools/verilator.py
+++ b/edalize/tools/verilator.py
@@ -123,7 +123,8 @@ class Verilator(Edatool):
             vc.append("-D{}={}".format(k, self._param_value_str(v)))
 
         self.vc = vc
-
+        if self.edam["flow_options"].get("cocotb_module"):
+        	self.toplevel = "top"
         mk_file = f"V{self.toplevel}.mk"
         exe_file = f"V{self.toplevel}"
         commands = EdaCommands()

--- a/edalize/tools/verilator.py
+++ b/edalize/tools/verilator.py
@@ -61,8 +61,7 @@ class Verilator(Edatool):
 
         if mode not in EdalizeVerilator.modes:
             _s = "Illegal verilator mode {}. Allowed values are {}"
-            raise RuntimeError(
-                _s.format(mode, ", ".join(EdalizeVerilator.modes)))
+            raise RuntimeError(_s.format(mode, ", ".join(EdalizeVerilator.modes)))
         vc.append("--" + mode)
 
         vc += self.tool_options.get("verilator_options", [])
@@ -118,14 +117,13 @@ class Verilator(Edatool):
 
         for k, v in self.vlogparam.items():
             vc.append(
-                "-G{}={}".format(k, self._param_value_str(v,
-                                 str_quote_style='\\"'))
+                "-G{}={}".format(k, self._param_value_str(v, str_quote_style='\\"'))
             )
         for k, v in self.vlogdefine.items():
             vc.append("-D{}={}".format(k, self._param_value_str(v)))
 
         self.vc = vc
-        if self.edam["flow_options"].get("cocotb_module"):
+        if self.edam.get("flow_options", {}).get("cocotb_module"):
             self.toplevel = "top"
             verilator_file += " `cocotb-config --share`/lib/verilator/verilator.cpp"
         mk_file = f"V{self.toplevel}.mk"
@@ -147,8 +145,7 @@ class Verilator(Edatool):
             commands.set_default_target(mk_file)
         else:
             commands.add(
-                ["make", "-f", mk_file] +
-                self.tool_options.get("make_options", []),
+                ["make", "-f", mk_file] + self.tool_options.get("make_options", []),
                 [exe_file],
                 [mk_file] + opt_c_files,
             )

--- a/edalize/tools/verilator.py
+++ b/edalize/tools/verilator.py
@@ -125,6 +125,7 @@ class Verilator(Edatool):
         self.vc = vc
         if self.edam["flow_options"].get("cocotb_module"):
         	self.toplevel = "top"
+        	verilator_file += " `cocotb-config --share`/lib/verilator/verilator.cpp"
         mk_file = f"V{self.toplevel}.mk"
         exe_file = f"V{self.toplevel}"
         commands = EdaCommands()


### PR DESCRIPTION
This PR adds verilator as a cocotb flow_tool simulation option by adding the cocotb "extend an existing build flow" options in sim.py. It also adds a switch to the verilator makefile call to use "Vtop.mk" instead of "V 'cocotb-module'.mk".

A cocotb simulation running on verilator can then be run using just the following fusesoc simulation configuration

  ```default:
    flow: sim
    flow_options:
      tool : verilator
      cocotb_module : test_file
      timescale: 1ns/1ns
    filesets : [rtl,cocotb]
    toplevel : [toplevel]```