### PR TITLE
Add Vivado power optimization option flag

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -1,5 +1,9 @@
 # Create a bin file which can be used to program the flash on the FPGA
 set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+{% if tool_options.power_opt == 1 -%}
+# Enable power optimizations during implementation
+set_property strategy Power_DefaultOpt [get_runs impl_1]
+{%- endif %}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.

--- a/edalize/tools/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/tools/templates/vivado/vivado-run.tcl.j2
@@ -1,5 +1,9 @@
 # Create a bin file which can be used to program the flash on the FPGA
 set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+{% if power_opt == 1 -%}
+# Enable power optimizations during implementation
+set_property strategy Power_DefaultOpt [get_runs impl_1]
+{%- endif %}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.

--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -64,6 +64,10 @@ class Vivado(Edatool):
             "type": "str",
             "desc": "A pattern matching a board identifier. Refer to the Vivado documentation for ``get_hw_targets`` for details. Example: ``*/xilinx_tcf/Digilent/123456789123A``",
         },
+        "power_opt": {
+            "type": "int",
+            "desc": "When set to 1, it enables the Power Optimization stage during implementation.",
+        },
     }
 
     def get_version(self):
@@ -182,9 +186,11 @@ class Vivado(Edatool):
             "bd_files": bd_files,
         }
         jobs = self.tool_options.get("jobs", None)
+        power_opt = self.tool_options.get("power_opt", None)
 
         self.run_template_vars = {
-            "jobs": " -jobs " + str(jobs) if jobs is not None else ""
+            "jobs": " -jobs " + str(jobs) if jobs is not None else "",
+            "power_opt": power_opt if power_opt is not None else 0,
         }
 
         self.synth_template_vars = {

--- a/edalize/vivado.py
+++ b/edalize/vivado.py
@@ -91,6 +91,11 @@ class Vivado(Edatool):
                         "type": "String",
                         "desc": "",
                     },
+                    {
+                        "name": "power_opt",
+                        "type": "int",
+                        "desc": "When defined, it enables the Power Optimization stage during implementation.",
+                    },
                 ],
             }
 


### PR DESCRIPTION
This proposal adds a flag to enable power optimization during implementation stage of a Vivado run.
Power optimization can have huge impacts, especially when using a device that has a PS (Processing System).

To use this new option, simply add the following flag in your `*.core` file:
```bash
flow_options :
            part           : xczu3eg-sfvc784-1-e
            power_opt      : 1
```

If set to 0, it will disable the power optimizations (and also if the options is not specified at all)