### PR TITLE
Handle the new XML format for QSys from version 23.

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -188,12 +188,16 @@ class Quartus(Edatool):
                         tool = qsysTree.find("component").attrib["tool"]
                     except AttributeError:
                         tool = qsysTree.find(".//{http://www.altera.com/XMLSchema/IPXact2014/extensions}tool").text
-                    if tool == "QsysPro" and self.isPro:
+                    if tool == "QsysPro":
+                        if self.isPro:
+                            name = f.name
+                    elif not self.isPro:
                         name = f.name
                 except (AttributeError, KeyError):
                     # Either a component wasn't found in the QSYS file, or it
                     # had no associated tool information. Make the assumption
-                    # it was a Standard edition file
+                    # it is a Standard edition file, as the old formats just
+                    # don't specify.
                     if not self.isPro:
                         name = f.name
             except (ET.ParseError, IOError):

--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -184,7 +184,10 @@ class Quartus(Edatool):
             try:
                 qsysTree = ET.parse(os.path.join(self.work_root, f.name))
                 try:
-                    tool = qsysTree.find("component").attrib["tool"]
+                    try:
+                        tool = qsysTree.find("component").attrib["tool"]
+                    except AttributeError:
+                        tool = qsysTree.find(".//{http://www.altera.com/XMLSchema/IPXact2014/extensions}tool").text
                     if tool == "QsysPro" and self.isPro:
                         name = f.name
                 except (AttributeError, KeyError):

--- a/tests/test_quartus.py
+++ b/tests/test_quartus.py
@@ -10,12 +10,31 @@ qsys_file = """<?xml version="1.0" encoding="UTF-8"?>
    description=""
    tags=""
    categories="System"
-   {}
+   tool="{}"
    />
 </system>
 """
 
-qsys_fill = {"Standard": "", "Pro": 'tool="QsysPro"'}
+qsys23_file = """<?xml version="1.0" ?>
+<ipxact:design xmlns:altera="http://www.altera.com/XMLSchema/IPXact2014/extensions" xmlns:ipxact="http://www.accellera.org/XMLSchema/IPXACT/1685-2014">
+  <ipxact:vendor>Altera Corporation</ipxact:vendor>
+  <ipxact:library>sdm_mailbox</ipxact:library>
+  <ipxact:name>sdm_mailbox</ipxact:name>
+  <ipxact:version>1.0</ipxact:version>
+  <ipxact:componentInstances></ipxact:componentInstances>
+  <ipxact:vendorExtensions>
+    <altera:catalog_card_info>
+      <altera:version>1.0</altera:version>
+      <altera:description></altera:description>
+      <altera:tags></altera:tags>
+      <altera:categories></altera:categories>
+      <altera:tool>{}</altera:tool>
+    </altera:catalog_card_info>
+  </ipxact:vendorExtensions>
+</ipxact:design>
+"""
+
+qsys_fill = {"Standard": "", "Pro": "QsysPro"}
 
 test_sets = {
     "Standard": {
@@ -64,30 +83,31 @@ def test_quartus(make_edalize_test):
     # Test each edition of Quartus
     for edition in ["Standard", "Pro"]:
         for pnr in ["Quartus", "DSE"]:
-            # Each edition and P&R tool has its own set of representative files
-            if pnr == "DSE":
-                _tool_options = {**tool_options, "pnr": "dse"}
-            else:
-                _tool_options = {**tool_options}
+            for qsys_format in [qsys_file, qsys23_file]:
+                # Each edition and P&R tool has its own set of representative files
+                if pnr == "DSE":
+                    _tool_options = {**tool_options, "pnr": "dse"}
+                else:
+                    _tool_options = {**tool_options}
 
-            # Ensure we test the edition we intend to, even if quartus_sh is
-            # present
-            os.environ["FUSESOC_QUARTUS_EDITION"] = edition
+                # Ensure we test the edition we intend to, even if quartus_sh is
+                # not present
+                os.environ["FUSESOC_QUARTUS_EDITION"] = edition
 
-            tf = make_edalize_test(
-                "quartus",
-                param_types=["vlogdefine", "vlogparam"],
-                tool_options=_tool_options,
-                ref_dir=edition,
-            )
+                tf = make_edalize_test(
+                    "quartus",
+                    param_types=["vlogdefine", "vlogparam"],
+                    tool_options=_tool_options,
+                    ref_dir=edition,
+                )
 
-            # Each edition performs checks on the QSYS files present, so
-            # provide a minimal example
-            with open(os.path.join(tf.work_root, "qsys_file"), "w") as f:
-                f.write(qsys_file.format(qsys_fill[edition]))
+                # Each edition performs checks on the QSYS files present, so
+                # provide a minimal example
+                with open(os.path.join(tf.work_root, "qsys_file"), "w") as f:
+                    f.write(qsys_format.format(qsys_fill[edition]))
 
-            tf.backend.configure()
-            tf.compare_files(["Makefile", tf.test_name + ".tcl"])
+                tf.backend.configure()
+                tf.compare_files(["Makefile", tf.test_name + ".tcl"])
 
-            tf.backend.build()
-            tf.compare_files(test_sets[edition][pnr])
+                tf.backend.build()
+                tf.compare_files(test_sets[edition][pnr])


### PR DESCRIPTION
It seems the format for QSys files changed significantly at some point, with at least version 23 using a completely different XML schema to before. This PR attempts version sanity checking using both formats. This should fix issue #417.