### PR TITLE
Update questaformal.py

### DIFF
--- a/edalize/questaformal.py
+++ b/edalize/questaformal.py
@@ -108,9 +108,9 @@ class Questaformal(Edatool):
                 cmd = "vcom"
                 if f.file_type.endswith("-87"):
                     args = ["-87"]
-                if f.file_type.endswith("-93"):
+                elif f.file_type.endswith("-93"):
                     args = ["-93"]
-                if f.file_type.endswith("-2008"):
+                elif f.file_type.endswith("-2008"):
                     args = ["-2008"]
                 else:
                     args = []


### PR DESCRIPTION
Because of the seperate if conditions, args gets the empty list value when file type endswith -87 or -93.