### PR TITLE
add SDC file type to radiant

### DIFF
--- a/edalize/radiant.py
+++ b/edalize/radiant.py
@@ -114,6 +114,7 @@ prj_close
             "systemVerilogSource": "prj_add_source ",
             "vhdlSource": "prj_add_source ",
             "PDC": "prj_add_source ",
+            "SDC": "prj_add_source ",
         }
         _file_type = get_file_type(f)
         if _file_type in file_types:


### PR DESCRIPTION
SDC files are supported and allow for multiple constraint files vs only one with PDC.