### PR TITLE
Use deepmerge package for merging dicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,9 +91,7 @@ setup(
         "setuptools_scm < 7.0; python_version<'3.7'",
         "setuptools_scm; python_version>='3.7'",
     ],
-    install_requires=[
-        "Jinja2>=3",
-    ],
+    install_requires=["Jinja2>=3", "deepmerge>=0.0.5"],
     tests_require=["pytest>=3.3.0", "vunit_hdl>=4.0.8"],
     # The reporting modules have dependencies that shouldn't be required for
     # all Edalize users.


### PR DESCRIPTION
Use the deepmerge package for merging dicts. This also provides a simple solution for #431. I used the merge_or_raise merger for merging edam files. This merger raises an Exception if no merging is possible.
Behavior for the other merges is the same as before.


I also tested this with deepmerge version 0.0.5, which is available in the ubuntu 20.04 repository. So this should be backwards compatible to older python versions.