### PR TITLE
Extend Vivado run script to support FPGAs of the Versal family

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -30,5 +32,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/edalize/tools/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/tools/templates/vivado/vivado-run.tcl.j2
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/test_vivado/board_file/test_vivado_0_run.tcl
+++ b/tests/test_vivado/board_file/test_vivado_0_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/test_vivado/test_vivado_0_run.tcl
+++ b/tests/test_vivado/test_vivado_0_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
+++ b/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/tools/vivado/design_run.tcl
+++ b/tests/tools/vivado/design_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}

--- a/tests/tools/vivado/tags/design_run.tcl
+++ b/tests/tools/vivado/tags/design_run.tcl
@@ -1,5 +1,7 @@
 # Create a bin file which can be used to program the flash on the FPGA
-set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+if { [llength [list_property [get_runs impl_1] STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE]] } {
+  set_property STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE true [get_runs impl_1]
+}
 
 # Vivado will raise an error if impl_1 is launched when it is already done. So
 # check the progress first and only launch if its not complete.
@@ -29,5 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
-file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+  file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
+}


### PR DESCRIPTION
Building bitstreams for the Versal family was not yet supported through the run script for Vivado. This change adds support for Versal FPGA's by the following means:

- The property `STEPS.WRITE_BITSTREAM.ARGS.BIN_FILE` is only set if it exists. For the Versal family, this step has been replaced by `write_device_image` and hence the property would not apply, throwing an error
- Versal bitstream files are ending in `.bif` instead of `.bit`, which made copying the `.bit` file throw an error. Now, after completion of the run, either a `.bit` or `.bif` file will be copied to the project workroot.

The test reference files have been updated accordingly...