### PR TITLE
#451: Minor README update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ directly in the Python console.
 
 First we have to import Edalize objects::
 
-  from edalize import *
+  from edalize.edatool import get_edatool
 
 The os module is also required for this tutorial::
 


### PR DESCRIPTION
# Description of the Issue:

I am encountering a NameError when running the script failing.py. The issue appears to be related to the way I am importing the edalize module. When importing the module as described in the README (from edalize import *), I get an error. However, when importing only the get_edatool function (from edalize.edatool import get_edatool), the script runs successfully.

# Resolution:

I've updated README