### PR TITLE
Support passing `vlogparam`s to Genus

### DIFF
--- a/edalize/genus.py
+++ b/edalize/genus.py
@@ -86,6 +86,10 @@ class Genus(Edatool):
         jobs = self.tool_options.get("jobs", None)
         jobs = "$nproc" if "all" in jobs else jobs
 
+        # Build up parameters in the format that the `elaborate` command expects
+        parameters = [f"{{ {name} {value} }}" for name, value in self.vlogparam.items()]
+        elaborate_parameters = "{ " + " ".join(parameters) + " }"
+
         template_vars = {
             "name": self.name,
             "src_files": src_files,
@@ -95,6 +99,7 @@ class Genus(Edatool):
             "genus_script": make_list(self.tool_options.get("genus_script")),
             "report_dir": make_list(self.tool_options.get("report_dir")),
             "common_config": make_list(self.tool_options.get("common_config")),
+            "parameters": elaborate_parameters,
             "jobs": make_list(jobs),
             "toplevel": self.toplevel,
         }

--- a/edalize/templates/genus/genus-project.tcl.j2
+++ b/edalize/templates/genus/genus-project.tcl.j2
@@ -28,6 +28,12 @@ set_multi_cpu_usage -local_cpu {{jobs}}
 
 set READ_SOURCES {{ name }}-read-sources
 
+# A variable containing all top-module parameters passed by FuseSoC, ready to
+# be passed on to the `elaborate`-command (within the `$GENUS_SCRIPT` like this:
+#
+#     elaborate -parameters "$ELABORATE_PARAMETERS" "$TOP_MODULE"
+set ELABORATE_PARAMETERS {{ parameters }}
+
 {% if script_dir -%}
 set SCRIPT_DIR {{ script_dir }}
 {% else %}


### PR DESCRIPTION
_Note_: this is written from the viewpoint of a FuseSoC user, but this applies to all usages of edalize itself.

FuseSoC already accepts `vlogparam`s for the `genus` backend/tool, but does not write them to any TCL-file or other way to access it from the user-defined Genus script. Therefore one could not easily add parameters to the top-level module when synthesizing with Genus, effectively rendering them unusable.

In order to resolve this issue, this commit creates new variable called `ELABORATE_PARAMETERS`, which is set unconditionally. Its value is constructed in such a way, that the value can be passed directly to the `elaborate`-command inside the user-supplied Genus TCL script like so:
```tcl
elaborate -parameters "$ELABORATE_PARAMETERS" "$TOP_MODULE"
```
This way, the user-supplied TCL-script can be kept generic (without the need for special-casing parameter) and FuseSoC makes use of the defined parameters.