### PR TITLE
Copy PDI instead of BIF and allow multiple PDI files

### DIFF
--- a/edalize/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/templates/vivado/vivado-run.tcl.j2
@@ -32,6 +32,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/edalize/tools/templates/vivado/vivado-run.tcl.j2
+++ b/edalize/tools/templates/vivado/vivado-run.tcl.j2
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/board_file/test_vivado_0_run.tcl
+++ b/tests/test_vivado/board_file/test_vivado_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/edif_netlist/test_vivado_0_run.tcl
+++ b/tests/test_vivado/edif_netlist/test_vivado_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/edif_netlist_no_link_design/test_vivado_0_run.tcl
+++ b/tests/test_vivado/edif_netlist_no_link_design/test_vivado_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
+++ b/tests/test_vivado/minimal/test_vivado_minimal_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/test_vivado_0_run.tcl
+++ b/tests/test_vivado/test_vivado_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
+++ b/tests/test_vivado/yosys/test_vivado_yosys_0_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/tools/vivado/design_run.tcl
+++ b/tests/tools/vivado/design_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }

--- a/tests/tools/vivado/tags/design_run.tcl
+++ b/tests/tools/vivado/tags/design_run.tcl
@@ -31,6 +31,6 @@ if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
 # The Vivado default name is beneficial when using the GUI, as it is set as
 # default bitstream in the "Program Device" dialog; non-standard names need to
 # be selected from a file picker first.
-foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] .{bit,bif}] {
+foreach vivadoBitstreamFile [glob -path [file rootname [get_property DIRECTORY [current_run]]/[get_property top [current_fileset]]] *.{bit,pdi}] {
   file copy -force $vivadoBitstreamFile [pwd]/[current_project][file extension $vivadoBitstreamFile]
 }


### PR DESCRIPTION
The BIF is used by bootgen to create the PDI, the actual device image, so it makes more sense to copy the PDI. A vivado project setting for Versal, called "segmented configuration" results in multiple PDI files, so it makes sense to copy all of them.