### PR TITLE
Change Vivado project not to be order only dep

### DIFF
--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -219,8 +219,7 @@ class Vivado(Edatool):
             commands.add(
                 vivado_command + tcl_scripts + [project_file],
                 targets,
-                tcl_scripts,
-                [project_file],
+                tcl_scripts + [project_file],
             )
         else:
             targets = edif_files
@@ -233,8 +232,7 @@ class Vivado(Edatool):
         commands.add(
             command=vivado_command + tcl_scripts + [project_file],
             targets=[bitstream],
-            depends=tcl_scripts,
-            order_only_deps=[project_file],
+            depends=tcl_scripts + [project_file],
         )
 
         commands.add(["vivado", project_file], ["build-gui"], [project_file])

--- a/tests/test_vivado/Makefile
+++ b/tests/test_vivado/Makefile
@@ -7,12 +7,12 @@ pre_build:
 test_vivado_0.xpr: test_vivado_0.tcl sdc_file sv_file.sv tcl_file.tcl vlog_file.v vlog_with_define.v vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file xci_file.xci xdc_file.xdc bootrom.mem another_sv_file.sv | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0.tcl
 
-test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr
 
 synth: test_vivado_0.v test_vivado_0.edn | pre_build
 
-test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr
 
 build-gui: test_vivado_0.xpr | pre_build

--- a/tests/test_vivado/board_file/Makefile
+++ b/tests/test_vivado/board_file/Makefile
@@ -7,12 +7,12 @@ pre_build:
 test_vivado_0.xpr: test_vivado_0.tcl sdc_file sv_file.sv tcl_file.tcl vlog_file.v vlog_with_define.v vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file xci_file.xci xdc_file.xdc bootrom.mem another_sv_file.sv | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0.tcl
 
-test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr
 
 synth: test_vivado_0.v test_vivado_0.edn | pre_build
 
-test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr
 
 build-gui: test_vivado_0.xpr | pre_build

--- a/tests/test_vivado/edif_netlist/Makefile
+++ b/tests/test_vivado/edif_netlist/Makefile
@@ -7,12 +7,12 @@ pre_build:
 test_vivado_0.xpr: test_vivado_0.tcl netlist.edif netlist.edif | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0.tcl
 
-test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr
 
 synth: test_vivado_0.v test_vivado_0.edn | pre_build
 
-test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr
 
 build-gui: test_vivado_0.xpr | pre_build

--- a/tests/test_vivado/edif_netlist_no_link_design/Makefile
+++ b/tests/test_vivado/edif_netlist_no_link_design/Makefile
@@ -7,12 +7,12 @@ pre_build:
 test_vivado_0.xpr: test_vivado_0.tcl netlist.edif netlist.edif | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0.tcl
 
-test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.v test_vivado_0.edn: test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_netlist.tcl test_vivado_0.xpr
 
 synth: test_vivado_0.v test_vivado_0.edn | pre_build
 
-test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl | pre_build test_vivado_0.xpr
+test_vivado_0.bit: test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_0_synth.tcl test_vivado_0_run.tcl test_vivado_0.xpr
 
 build-gui: test_vivado_0.xpr | pre_build

--- a/tests/test_vivado/minimal/Makefile
+++ b/tests/test_vivado/minimal/Makefile
@@ -7,12 +7,12 @@ pre_build:
 test_vivado_minimal_0.xpr: test_vivado_minimal_0.tcl | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_minimal_0.tcl
 
-test_vivado_minimal_0.v test_vivado_minimal_0.edn: test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_netlist.tcl | pre_build test_vivado_minimal_0.xpr
+test_vivado_minimal_0.v test_vivado_minimal_0.edn: test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_netlist.tcl test_vivado_minimal_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_netlist.tcl test_vivado_minimal_0.xpr
 
 synth: test_vivado_minimal_0.v test_vivado_minimal_0.edn | pre_build
 
-test_vivado_minimal_0.bit: test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_run.tcl | pre_build test_vivado_minimal_0.xpr
+test_vivado_minimal_0.bit: test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_run.tcl test_vivado_minimal_0.xpr | pre_build
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_minimal_0_synth.tcl test_vivado_minimal_0_run.tcl test_vivado_minimal_0.xpr
 
 build-gui: test_vivado_minimal_0.xpr | pre_build

--- a/tests/test_vivado/yosys/Makefile
+++ b/tests/test_vivado/yosys/Makefile
@@ -12,7 +12,7 @@ test_vivado_yosys_0.xpr: test_vivado_yosys_0.tcl test_vivado_yosys_0.edif test_v
 
 synth: test_vivado_yosys_0.edif
 
-test_vivado_yosys_0.bit: test_vivado_yosys_0_synth.tcl test_vivado_yosys_0_run.tcl | test_vivado_yosys_0.xpr
+test_vivado_yosys_0.bit: test_vivado_yosys_0_synth.tcl test_vivado_yosys_0_run.tcl test_vivado_yosys_0.xpr
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source test_vivado_yosys_0_synth.tcl test_vivado_yosys_0_run.tcl test_vivado_yosys_0.xpr
 
 build-gui: test_vivado_yosys_0.xpr

--- a/tests/tools/vivado/Makefile
+++ b/tests/tools/vivado/Makefile
@@ -5,12 +5,12 @@ all: design.bit
 design.xpr: design.tcl sdc_file sv_file.sv tcl_file.tcl vlog_file.v vlog_with_define.v vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file xci_file.xci xdc_file.xdc bootrom.mem another_sv_file.sv
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design.tcl
 
-design.v design.edn: design_synth.tcl design_netlist.tcl | design.xpr
+design.v design.edn: design_synth.tcl design_netlist.tcl design.xpr
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design_synth.tcl design_netlist.tcl design.xpr
 
 synth: design.v design.edn
 
-design.bit: design_synth.tcl design_run.tcl | design.xpr
+design.bit: design_synth.tcl design_run.tcl design.xpr
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design_synth.tcl design_run.tcl design.xpr
 
 build-gui: design.xpr

--- a/tests/tools/vivado/tags/Makefile
+++ b/tests/tools/vivado/tags/Makefile
@@ -5,12 +5,12 @@ all: design.bit
 design.xpr: design.tcl sdc_file sv_file.sv tcl_file.tcl vlog_file.v vlog_with_define.v vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file xci_file.xci xdc_file.xdc bootrom.mem another_sv_file.sv testbench.v
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design.tcl
 
-design.v design.edn: design_synth.tcl design_netlist.tcl | design.xpr
+design.v design.edn: design_synth.tcl design_netlist.tcl design.xpr
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design_synth.tcl design_netlist.tcl design.xpr
 
 synth: design.v design.edn
 
-design.bit: design_synth.tcl design_run.tcl | design.xpr
+design.bit: design_synth.tcl design_run.tcl design.xpr
 	$(EDALIZE_LAUNCHER) vivado -notrace -mode batch -source design_synth.tcl design_run.tcl design.xpr
 
 build-gui: design.xpr


### PR DESCRIPTION
Fixes olofk/edalize#423 by making the Vivado project a normal dependency of the other targets to ensure synthesis and implementation are rerun if a source file is updated.