### PR TITLE
 Add open-source toolchain support for GateMate

### DIFF
--- a/edalize/peppercorn.py
+++ b/edalize/peppercorn.py
@@ -1,0 +1,85 @@
+# Copyright edalize contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os.path
+import re
+
+from edalize.edatool import Edatool
+from edalize.nextpnr import Nextpnr
+from edalize.utils import EdaCommands
+from edalize.yosys import Yosys
+
+
+class Peppercorn(Edatool):
+
+    argtypes = ["vlogdefine", "vlogparam"]
+
+    @classmethod
+    def get_doc(cls, api_ver):
+        if api_ver == 0:
+            options = {
+                "members": [
+                    {
+                        "name": "device",
+                        "type": "String",
+                        "desc": "Required device option for nextpnr (e.g. CCGM1A1)",
+                    }
+                ],
+                "lists": [
+                    {
+                        "name": "gmpack_options",
+                        "type": "String",
+                        "desc": "Additional options for gmpack",
+                    },
+                ],
+            }
+
+            Edatool._extend_options(options, Yosys)
+            Edatool._extend_options(options, Nextpnr)
+
+            return {
+                "description": "Open source toolchain for CologneChip GateMate.",
+                "members": options["members"],
+                "lists": options["lists"],
+            }
+
+    def configure_main(self):
+        # Pass peppercorn options to yosys and nextpnr
+        self.edam["tool_options"] = {
+            "yosys": {
+                "arch": "gatemate",
+                "output_format": "json",
+                "yosys_synth_options": self.tool_options.get("yosys_synth_options", [
+                    "-luttree", "-nomx8"]),
+                "yosys_as_subtool": True,
+                "yosys_template": self.tool_options.get("yosys_template"),
+            },
+            "nextpnr": {
+                "device": self.tool_options.get("device"),
+                "nextpnr_options": self.tool_options.get("nextpnr_options", [])
+            },
+        }
+        
+        yosys = Yosys(self.edam, self.work_root)
+        yosys.configure()
+
+        nextpnr = Nextpnr(yosys.edam, self.work_root)
+        nextpnr.flow_config = {"arch": "gatemate"}
+        nextpnr.configure()
+
+        # Write Makefile
+        commands = EdaCommands()
+        commands.commands = yosys.commands
+
+        commands.commands += nextpnr.commands
+
+        # Image generation
+        depends = self.name + ".txt"
+        targets = self.name + ".bit"
+        options = " ".join(self.tool_options.get("gmpack_options", ""))
+        command = ["gmpack", options, depends, targets]
+        commands.add(command, [targets], [depends])
+
+        commands.set_default_target(self.name + ".bit")
+        commands.write(os.path.join(self.work_root, "Makefile"))


### PR DESCRIPTION
Adds `nextpnr-himbaechel` support for GateMate to edalize. Currently, edalize only supports the proprietary `p_r` tool for place&route.

Support for GateMate by nextpnr is added as a separate `.py` file instead of adding options to `gatemate.py` for the following reason:
* No change in the existing API. Even if a `pnr` option with a default value is added as in icestorm, the option `p_r_options` is no longer descriptive to carry the device information for nextpnr.
* Consistent naming convention: peppercorn for GateMate; as trellis for ECP5, icestorm for iCE40, and apicula for Gowin.
* Keeping required yosys flags separate: `-luttree`, `-nomx8`

Example fusesoc target:

```
  <name>:
    default_tool: peppercorn
    description: <desc>
    filesets: <filesets>
    parameters: <param>
    tools:
      peppercorn:
        device: CCGM1A1
        gmpack_options: [--crcmode, ignore]
    toplevel: <top>
```