### PR TITLE
Fix Vivado property usage for simulation files (#474)

### DIFF
--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -150,10 +150,7 @@ class Vivado(Edatool):
                         f"move_files -fileset sim_1 [get_files {f['name']}]"
                     )
                     sim_files.append(
-                        f"set_property used_in_synthesis false [get_files {f['name']}]"
-                    )
-                    sim_files.append(
-                        f"set_property used_in_implementation false [get_files {f['name']}]"
+                        f"set_property used_in simulation [get_files {f['name']}]"
                     )
                     unused_files.append(f)
 


### PR DESCRIPTION
 Replace `used_in_implementation` and `used_in_synthesis` with `used_in`

Vivado does not support `used_in_implementation` for all file types (e.g., Verilog and VHDL). Replaced both `used_in_implementation` and `used_in_synthesis` with the `used_in` property, which explicitly defines the allowed design flows and works consistently across all file types.