### PR TITLE
Add Cadence Xcelium simulator tool support to SIM flow.

### DIFF
--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -67,9 +67,9 @@ class Sim(Generic):
                     "xrun_options",
                     [
                         "-access +rwc",
-                        "-loadvpi $$(cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap"
-                    ]
-                )
+                        "-loadvpi $$(cocotb-config --lib-name-path vpi xcelium):vlog_startup_routines_bootstrap",
+                    ],
+                ),
             }
             (opt, val) = cocotb_options[tool]
             self.edam["tool_options"][tool][opt] = (

--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -9,6 +9,7 @@ from edalize.utils import EdaCommands
 
 logger = logging.getLogger(__name__)
 
+
 class Xcelium(Edatool):
     description = "Xcelium (xrun) simulator from Cadence"
 
@@ -17,19 +18,13 @@ class Xcelium(Edatool):
             "type": "bool",
             "desc": "Disable 64-bit mode",
         },
-        "timescale": {
-            "type": "str",
-            "desc": "Default timescale for simulation"
-        },
-        "xrun_options": {
-            "type": "str",
-            "desc": "Additional run options for xrun"
-        },
+        "timescale": {"type": "str", "desc": "Default timescale for simulation"},
+        "xrun_options": {"type": "str", "desc": "Additional run options for xrun"},
     }
 
     V_SRC_FILE_TYPES = ["verilogSource", "systemVerilogSource"]
     TCL_SCRIPT_TYPES = ["tclSource"]
-    DPIC_LIB_TYPES   = ["dpiLibrary"]
+    DPIC_LIB_TYPES = ["dpiLibrary"]
 
     def setup(self, edam):
         super().setup(edam)
@@ -84,7 +79,11 @@ class Xcelium(Edatool):
         sv_cmd = ["-sv"] if has_system_verilog else []
 
         # Append timescale option
-        timescale_cmd = ["-timescale", self.tool_options.get("timescale")] if self.tool_options.get("timescale") else []
+        timescale_cmd = (
+            ["-timescale", self.tool_options.get("timescale")]
+            if self.tool_options.get("timescale")
+            else []
+        )
 
         # Append TCL scripts
         tcl_cmd = []
@@ -101,7 +100,8 @@ class Xcelium(Edatool):
         for k, v in self.vlogdefine.items():
             macro_def_cmd.append(
                 "+define+{}={}".format(
-                    k, self._param_value_str(v, str_quote_style='""'))
+                    k, self._param_value_str(v, str_quote_style='""')
+                )
             )
 
         # Append include directories
@@ -123,7 +123,8 @@ class Xcelium(Edatool):
             + top_cmd
             + ["-f", "xrun.f"]
             + self.tool_options.get("xrun_options", []),
-            ["run"], include_files + tcl_files + dpi_libraries + ["xrun.f"]
+            ["run"],
+            include_files + tcl_files + dpi_libraries + ["xrun.f"],
         )
 
         self.commands.set_default_target("run")


### PR DESCRIPTION
Adds `xcelium` support for Cadence Xcelium simulator to Edalize. 
Currently, Edalize only supports Xcelium through the legacy tool API, while the newer flow API is required for cocotb integration.

With this patch, we can now use `xcelium` with or without the `cocotb_module` in the flow API.

## Options
The following options have been added for the tool:
- `32bit`: This `boolean` option will try run the Xcelium in 32-bit by remove `-64bit` argument from command line, the default value is `false`;
- `timescale`: The timescale option to give to `xrun` by `-timescale xxxxx`;
- `xrun_options`: Other arguments give to `xrun`, like `-debug`, `-lwdgen`, etc.

## Testing
This Edalize backend has been tested with FuseSoC using the following core file, and it works correctly.
```
targets:
  default:
    filesets:
      - rtl
      - cocotb
      - sim_script
    flow: sim
    toplevel: test
    flow_options:
      tool: xcelium
      cocotb_module: test_cocotb
      xrun_options:
          - -access +rwc -accessreg +rwc
          - -debug -classlinedebug -linedebug -source_debug -plidebug -fsmdebug
          - -lwdgen
      timescale: 1ns/1ps
```