### PR TITLE
Moved flow_make_options to Edaflow class

### DIFF
--- a/edalize/flows/edaflow.py
+++ b/edalize/flows/edaflow.py
@@ -138,6 +138,11 @@ class Edaflow(object):
             "desc": "Tools to run before main flow",
             "list": True,
         },
+        "flow_make_options": {
+            "type": "str",
+            "desc": "Additional options to pass to make when executing the flow graph",
+            "list": True,
+        },
     }
 
     @classmethod

--- a/edalize/flows/generic.py
+++ b/edalize/flows/generic.py
@@ -22,11 +22,6 @@ class Generic(Edaflow):
                 "type": "str",
                 "desc": "Select tool",
             },
-            "flow_make_options": {
-                "type": "str",
-                "desc": "Additional options to pass to make when executing the flow graph",
-                "list": True,
-            },
         },
     }
 


### PR DESCRIPTION
This PR fixes #480. The change makes flow_make_options accessible to all flows that inherit from Edaflow.