### PR TITLE
fix(slang): don't silence warnings (#484)

### DIFF
--- a/edalize/slang.py
+++ b/edalize/slang.py
@@ -134,7 +134,7 @@ Example snippet of a CAPI2 description file for Slang:
         self._get_slang_options()
         self._get_run_mode_flags()
         self._get_top_flags()
-        self._run_tool("slang", self.flags, quiet=True)
+        self._run_tool("slang", self.flags)
         return
 
     def configure_main(self):


### PR DESCRIPTION
Support for slang was added back in 2021 but it looks like the tool has always been run with quiet=True which means that only errors surface.