### PR TITLE
Added new envvars needed for cocotb

### DIFF
--- a/edalize/flows/edaflow.py
+++ b/edalize/flows/edaflow.py
@@ -293,6 +293,7 @@ class Edaflow(object):
 
         self.work_root = work_root
 
+        self.verbose = verbose
         self.stdout = None
         self.stderr = None
 

--- a/edalize/flows/sim.py
+++ b/edalize/flows/sim.py
@@ -78,9 +78,22 @@ class Sim(Generic):
 
         # Get run command from simulator
         (cmd, args, cwd) = run_tool.run()
+
+        # Get required cocotb env data
+        prev_verbose = self.verbose
+        self.verbose = False
+        _, libpy, _ = self._run_tool("cocotb-config", ["--libpython"], quiet=True)
+        _, pybin, _ = self._run_tool("cocotb-config", ["--python-bin"], quiet=True)
+        self.verbose = prev_verbose
+
         cocotb_module = self.flow_options.get("cocotb_module")
         env = (
-            {"MODULE": cocotb_module, "COCOTB_TEST_MODULES": cocotb_module}
+            {
+                "COCOTB_TEST_MODULES": cocotb_module,
+                "MODULE": cocotb_module,  # Keep for compatibility with cocotb < v2.0
+                "LIBPYTHON_LOC": libpy.decode("utf-8").strip(),
+                "PYGPI_PYTHON_BIN": pybin.decode("utf-8").strip(),
+            }
             if cocotb_module
             else {}
         )


### PR DESCRIPTION
Fixes #486. Also added a missing verbose field to the Edaflow class which caused the _run_tool method to fail when using it with quiet=True