### PR TITLE
New Tool Support: VC Formal

### DIFF
--- a/edalize/vcf.py
+++ b/edalize/vcf.py
@@ -1,0 +1,163 @@
+# Copyright edalize contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import re
+import logging
+import jinja2
+from edalize.edatool import Edatool
+
+logger = logging.getLogger(__name__)
+
+
+class Vcf(Edatool):
+
+    _description = """Synopsys Formal Backend
+
+VC Formal is Synopsys's formal verification tool. 
+
+example snippet of a a CAPI2 description file for VC Formal: 
+
+.. code:: yaml
+
+    vcf:
+      app: [FPV]
+
+"""
+    argtypes = ["plusarg", "vlogdefine", "vlogparam"]
+
+    tool_options = {
+        "lists": {
+            "app": "String",  # VC Formal App to Use
+        }
+    }
+
+    def __init__(self, edam=None, work_root=None, eda_api=None, verbose=True):
+        super(Vcf, self).__init__(edam, work_root, eda_api, verbose)
+
+        # The list of RTL paths in the fileset (populated at configure time by
+        # _get_file_names)
+        self.rtl_paths = None
+
+        # The list of include directories in the fileset (populated at configure time by
+        # _get_file_names)
+        self.incdirs = None
+
+        # The name of the interpolated .tcl file that we create in the work
+        # root
+        self.tcl_name = "vcf.tcl"
+
+    @staticmethod
+    def get_doc(api_ver):
+        if api_ver == 0:
+            return {
+                "description": "VCF formal verification tool",
+                "lists": [
+                    {"name": "app", "type": "String", "desc": ("VC Formal Application")}
+                ],
+            }
+
+    def _get_file_names(self):
+        """Read the fileset to get our file names"""
+        assert self.rtl_paths is None
+
+        src_files, self.incdirs = self._get_fileset_files()
+        self.rtl_paths = []
+        bn_to_path = {}
+        tcl_names = []
+
+        # RTL files have types verilogSource or systemVerilogSource*. We
+        # presumably want some of them. The .tcl file has type vcfConfigTemplate: we
+        # want exactly one of them.
+        ft_re = re.compile(r"(:?systemV|v)erilogSource")
+        for file_obj in src_files:
+            if ft_re.match(file_obj.file_type):
+                self.rtl_paths.append(file_obj.name)
+
+                # Check that basenames are unique
+                basename = os.path.basename(file_obj.name)
+                if basename in bn_to_path:
+                    raise RuntimeError(
+                        "More than one RTL file with the same"
+                        "basename: {!r} and {!r}.".format(
+                            bn_to_path[basename], file_obj.name
+                        )
+                    )
+
+                bn_to_path[basename] = file_obj.name
+                continue
+
+            if file_obj.file_type == "vcfConfigTemplate":
+                tcl_names.append(file_obj.name)
+                continue
+
+            # Ignore anything else
+
+        if len(tcl_names) != 1:
+            raise RuntimeError(
+                "VCF expects exactly one file with type "
+                "vcfConfigTemplate (the one called "
+                "something.tcl.j2). We have {}.".format(tcl_names or "none")
+            )
+
+        return tcl_names[0]
+
+    def _interpolate_tcl(self, src):
+        """
+        Interpolate the vcf targeted .tcl command file from its jinja2 template.
+
+        Input file is a a jinja2 template that has the commands necessary to
+        run VC Formal, sans the list of RTL files and include directories, as well
+        as the desired application to use
+
+        See class documentation for details of templating the .tcl file.
+        """
+
+        # This should be set by _get_file_names by now
+        assert self.rtl_paths is not None
+
+        src_path = os.path.join(self.work_root, src)
+        dst_path = os.path.join(self.work_root, self.tcl_name)
+
+        with open(src_path) as sf:
+            try:
+                template = self.jinja_env.from_string(sf.read())
+            except jinja2.TemplateError as err:
+                raise RuntimeError(
+                    "Failed to load {!r} "
+                    "as a Jijnja2 template: {}".format(src_path, err)
+                )
+
+        new_incdir = []
+        for incdir in self.incdirs:
+            new_incdir.append(f"+incdir+{incdir}")
+
+        files = " ".join(new_incdir + self.rtl_paths)
+
+        template_ctxt = {
+            "app": self.tool_options.get("app"),
+            "files": files,
+            "top_level": self.toplevel,
+        }
+
+        with open(dst_path, "w") as df:
+            df.write(template.render(template_ctxt))
+
+    def configure_main(self):
+        clean_tcl_name = self._get_file_names()
+        self._interpolate_tcl(clean_tcl_name)
+
+    def build_main(self, target=None):
+        pass
+
+    def run_main(self):
+        self._run_tool(
+            "vcf",
+            [
+                "-batch",
+                f"-f {self.tcl_name}",
+                "-output_log_file vcf.log",
+                "-lic_wait 240",
+            ],
+        )

--- a/tests/edalize_common.py
+++ b/tests/edalize_common.py
@@ -239,6 +239,7 @@ FILES = [
     {"name": "verible_waiver.vbw", "file_type": "veribleLintWaiver"},
     {"name": "verible_waiver2.vbw", "file_type": "veribleLintWaiver"},
     {"name": "config.sby.j2", "file_type": "sbyConfigTemplate"},
+    {"name": "config.tcl.j2", "file_type": "vcfConfigTemplate"},
     {"name": "another_sv_file.sv", "file_type": "systemVerilogSource"},
     {"name": "pdc_constraint_file.pdc", "file_type": "PDC"},
     {"name": "qsf_constraint_file.qsf", "file_type": "QSF"},

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,0 +1,26 @@
+from .edalize_common import make_edalize_test
+
+
+def test_vcf(make_edalize_test):
+    tf = make_edalize_test(
+        "vcf",
+        paramtypes=["plusarg", "vlogdefine", "vlogparam"],
+        tool_options={"app": ["FPV"]},
+    )
+
+    # Copy example jinja template to work root
+    tf.copy_to_work_root("config.tcl.j2")
+
+    # Ensure our tcl is properly generated during config
+    tf.backend.configure()
+
+    tf.compare_file(["vcf.tcl"])
+
+    # This should not do anything
+    tf.backend.build()
+
+    # Should run vcf, but for our case, just generates the command
+    # for us to compare
+    tf.backend.run()
+
+    tf.compare_files(["vcf.cmd"])

--- a/tests/test_vcf/config.tcl.j2
+++ b/tests/test_vcf/config.tcl.j2
@@ -1,0 +1,20 @@
+# VC Formal Test TCL Script
+set_fml_appmode {{ app }}
+read_file -top {{ top_level }} -format sverilog -sva -vcs "-assert svaext -sverilog {{ files }}"
+
+create_clock w_clk -period 100
+create_clock r_clk -period 150
+create_reset w_rst -sense high
+
+sim_config -default_input 0 
+sim_run -stable 
+sim_force w_rst -apply 1'b0
+sim_run -stable 
+sim_save_reset 
+
+if ($in_gui_session) { 
+    set_fml_var fml_witness_on true
+} else {
+    check_fv -block
+    exit
+}

--- a/tests/test_vcf/vcf.cmd
+++ b/tests/test_vcf/vcf.cmd
@@ -1,0 +1,1 @@
+-batch -f test.tcl -output_log_file vcf.log -lic_wait 240

--- a/tests/test_vcf/vcf.tcl
+++ b/tests/test_vcf/vcf.tcl
@@ -1,0 +1,20 @@
+# VC Formal Test TCL Script
+set_fml_appmode FPV
+read_file -top topmodule -format sverilog -sva -vcs "-assert svaext -sverilog sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv"
+
+create_clock w_clk -period 100
+create_clock r_clk -period 150
+create_reset w_rst -sense high
+
+sim_config -default_input 0 
+sim_run -stable 
+sim_force w_rst -apply 1'b0
+sim_run -stable 
+sim_save_reset 
+
+if ($in_gui_session) { 
+    set_fml_var fml_witness_on true
+} else {
+    check_fv -block
+    exit
+}


### PR DESCRIPTION
# Add [VC Formal support](https://www.synopsys.com/verification/static-and-formal-verification/vc-formal.html) to Edalize

## Feature Overview 
* Utilize similar jinja template method to that of the symbiyosys to run vcformal (vcf) applications 
* CAPI2 selected VC formal application (FPV, FSV, etc.) mandatory tool option
* Add new filetype, vcfConfigTemplate, to CAPI2 file typing system

## Verification
* Add testing for vcf tcl file generation, tests against assumed CLI command (most information contained in template .tcl file) 
* In use in fork w/ VCF 2024


