### PR TITLE
Add Quartus DRC PNR option

### DIFF
--- a/edalize/quartus.py
+++ b/edalize/quartus.py
@@ -55,7 +55,7 @@ class Quartus(Edatool):
                     {
                         "name": "pnr",
                         "type": "String",
-                        "desc": "P&R tool. Allowed values are quartus (default), dse (to run Design Space Explorer) and none (to just run synthesis)",
+                        "desc": "P&R tool. Allowed values are quartus (default), dse (to run Design Space Explorer), drc (to run Design Rule Check) and none (to just run synthesis)",
                     },
                     {
                         "name": "pgm",
@@ -272,6 +272,8 @@ class Quartus(Edatool):
                 pass
             elif self.tool_options["pnr"] == "dse":
                 args.append("dse")
+            elif self.tool_options["pnr"] == "drc":
+                args.append("drc")
             elif self.tool_options["pnr"] == "none":
                 args.append("syn")
         self._run_tool("make", args, quiet=True)

--- a/edalize/templates/quartus/quartus-std-makefile.j2
+++ b/edalize/templates/quartus/quartus-std-makefile.j2
@@ -20,6 +20,9 @@ syn: qsys
 fit: syn
 	$(EDALIZE_LAUNCHER) quartus_fit $(OPTIONS) $(NAME)
 
+drc: syn
+	$(EDALIZE_LAUNCHER) quartus_drc $(OPTIONS) $(NAME)
+
 asm: fit
 	$(EDALIZE_LAUNCHER) quartus_asm $(OPTIONS) $(NAME)
 

--- a/tests/test_quartus/Standard/Makefile
+++ b/tests/test_quartus/Standard/Makefile
@@ -18,6 +18,9 @@ syn: qsys
 fit: syn
 	$(EDALIZE_LAUNCHER) quartus_fit $(OPTIONS) $(NAME)
 
+drc: syn
+	$(EDALIZE_LAUNCHER) quartus_drc $(OPTIONS) $(NAME)
+
 asm: fit
 	$(EDALIZE_LAUNCHER) quartus_asm $(OPTIONS) $(NAME)
 


### PR DESCRIPTION
## Summary 
Simple addition of quartus_drc as a post-synth tool call option. 

## Testing 
* Modify expected make file to include drc target
* Working on forked repo w/ quartus 13.1 & 20+ 