### PR TITLE
Add C/C++ File Support to Sim Flow VCS Tool

### DIFF
--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -137,7 +137,7 @@ class Vcs(Edatool):
                 )
             elif file_type == "user":
                 user_files.append(f["name"])
-            elif file_type == "cSource":
+            elif file_type == "cSource" or file_type == "cppSource":
                 c_files.append(fname)
                 unused_files.remove(f)
 
@@ -197,7 +197,7 @@ class Vcs(Edatool):
             elif file_type == "user":
                 self.user_files.append(f["name"])
                 cmd = None
-            elif file_type == "cSource":
+            elif file_type == "cSource" or file_type == "cppSource":
                 c_files.append(f["name"])
                 cmd = None
             else:

--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -111,6 +111,9 @@ class Vcs(Edatool):
         user_files = []
 
         vlog_files = []
+
+        c_files = []
+
         has_sv = False
         for f in unused_files.copy():
             if not "simulation" in f.get("tags", ["simulation"]):
@@ -134,6 +137,9 @@ class Vcs(Edatool):
                 )
             elif file_type == "user":
                 user_files.append(f["name"])
+            elif file_type == "cSource":
+                c_files.append(fname)
+                unused_files.remove(f)
 
             if f.get("define"):
                 logger.warning(
@@ -159,11 +165,12 @@ class Vcs(Edatool):
 
         self.f_files["vcs.f"] = options
 
-        self.target_files = include_files + vlog_files
-        self.vcs_files = vlog_files
+        self.target_files = include_files + vlog_files + c_files
+        self.vcs_files = vlog_files + c_files
 
     def _threestage_setup(self, edam, incdirs, include_files, unused_files, full64):
         filegroups = []
+        c_files = []
         prev_fileopts = ("", "", "")  # file_type, logical_name, defines
         for f in unused_files.copy():
             lib = f.get("logical_name", "work")
@@ -189,6 +196,9 @@ class Vcs(Edatool):
                 cmd = "vhdlan"
             elif file_type == "user":
                 self.user_files.append(f["name"])
+                cmd = None
+            elif file_type == "cSource":
+                c_files.append(f["name"])
                 cmd = None
             else:
                 cmd = None
@@ -255,8 +265,8 @@ class Vcs(Edatool):
 
         self.commands.add(cmds, self.target_files, depfiles + list(self.f_files.keys()))
 
-        self.f_files["vcs.f"] = ["-top", self.toplevel] + self.tool_options.get(
-            "vcs_options", []
+        self.f_files["vcs.f"] = (
+            ["-top", self.toplevel] + self.tool_options.get("vcs_options", []) + c_files
         )
         self.vcs_files = []
 

--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -222,7 +222,7 @@ class Vcs(Edatool):
         for fg in filegroups:
             # Ignore empty file groups
             if fg[1]:
-                (cmd, file_type, lib, defines) = fg[0]
+                cmd, file_type, lib, defines = fg[0]
                 depfiles += fg[1]
                 options = self.tool_options.get("analysis_options", []).copy()
                 if cmd == "vlogan":

--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -73,7 +73,7 @@ class Vcs(Edatool):
                 continue
             file_type = f.get("file_type", "")
             if file_type.startswith("verilogSource") or file_type.startswith(
-                "systemVerilogSource"
+                "systemVerilogSource" or file_type.startswith("cSource")
             ):
                 if self._add_include_dir(f, incdirs, force_slash=True):
                     include_files.append(f["name"])

--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -72,8 +72,11 @@ class Vcs(Edatool):
             if not "simulation" in f.get("tags", ["simulation"]):
                 continue
             file_type = f.get("file_type", "")
-            if file_type.startswith("verilogSource") or file_type.startswith(
-                "systemVerilogSource" or file_type.startswith("cSource")
+            if (
+                file_type.startswith("verilogSource")
+                or file_type.startswith("systemVerilogSource")
+                or file_type.startswith("cSource")
+                or file_type.startswith("cppSource")
             ):
                 if self._add_include_dir(f, incdirs, force_slash=True):
                     include_files.append(f["name"])

--- a/edalize/tools/vcs.py
+++ b/edalize/tools/vcs.py
@@ -65,28 +65,35 @@ class Vcs(Edatool):
         self.user_files = []
 
         incdirs = []
-        include_files = []
+        rtl_include_files = []
+        c_include_files = []
         unused_files = self.files.copy()
         # Get all include dirs. Move include files to a separate list
         for f in self.files:
             if not "simulation" in f.get("tags", ["simulation"]):
                 continue
             file_type = f.get("file_type", "")
-            if (
-                file_type.startswith("verilogSource")
-                or file_type.startswith("systemVerilogSource")
-                or file_type.startswith("cSource")
-                or file_type.startswith("cppSource")
+            if file_type.startswith("verilogSource") or file_type.startswith(
+                "systemVerilogSource"
             ):
                 if self._add_include_dir(f, incdirs, force_slash=True):
-                    include_files.append(f["name"])
+                    rtl_include_files.append(f["name"])
+                    unused_files.remove(f)
+
+            elif file_type.startswith("cSource") or file_type.startswith("cppSource"):
+                if self._add_include_dir(f, incdirs, force_slash=True):
+                    c_include_files.append(f["name"])
                     unused_files.remove(f)
 
         full64 = [] if self.tool_options.get("32bit") else ["-full64"]
         if self.tool_options.get("2_stage_flow"):
-            self._twostage_setup(edam, incdirs, include_files, unused_files, full64)
+            self._twostage_setup(
+                edam, incdirs, rtl_include_files, c_include_files, unused_files, full64
+            )
         else:
-            self._threestage_setup(edam, incdirs, include_files, unused_files, full64)
+            self._threestage_setup(
+                edam, incdirs, rtl_include_files, c_include_files, unused_files, full64
+            )
 
         self.edam = edam.copy()
         self.edam["files"] = unused_files
@@ -109,7 +116,9 @@ class Vcs(Edatool):
         )
         self.commands.set_default_target(binary_name)
 
-    def _twostage_setup(self, edam, incdirs, include_files, unused_files, full64):
+    def _twostage_setup(
+        self, edam, incdirs, rtl_include_files, c_include_files, unused_files, full64
+    ):
 
         user_files = []
 
@@ -168,10 +177,12 @@ class Vcs(Edatool):
 
         self.f_files["vcs.f"] = options
 
-        self.target_files = include_files + vlog_files + c_files
+        self.target_files = rtl_include_files + c_include_files + vlog_files + c_files
         self.vcs_files = vlog_files + c_files
 
-    def _threestage_setup(self, edam, incdirs, include_files, unused_files, full64):
+    def _threestage_setup(
+        self, edam, incdirs, rtl_include_files, c_include_files, unused_files, full64
+    ):
         filegroups = []
         c_files = []
         prev_fileopts = ("", "", "")  # file_type, logical_name, defines
@@ -235,7 +246,7 @@ class Vcs(Edatool):
                     options += [defines]
                     options += ["+incdir+" + d for d in incdirs]
                     target_file = f"{lib}.workdir/AN.DB/make.vlogan"
-                    depfiles += include_files
+                    depfiles += rtl_include_files
                 elif cmd == "vhdlan":
                     options += self.tool_options.get("vhdlan_options", [])
                     target_file = f"{lib}.workdir/64/vhmra.sdb"
@@ -265,7 +276,7 @@ class Vcs(Edatool):
                     + ["-file", f_file, "-work", lib, "-l", logfile]
                     + fg[1]
                 )
-
+        depfiles += c_include_files
         self.commands.add(cmds, self.target_files, depfiles + list(self.f_files.keys()))
 
         self.f_files["vcs.f"] = (

--- a/tests/tools/vcs/2stage_basic/Makefile
+++ b/tests/tools/vcs/2stage_basic/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h
+design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS) and some run options

--- a/tests/tools/vcs/2stage_basic/Makefile
+++ b/tests/tools/vcs/2stage_basic/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv
+design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS) and some run options

--- a/tests/tools/vcs/2stage_basic/Makefile
+++ b/tests/tools/vcs/2stage_basic/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h
+design: vlog_incfile c_header.h c_header.h sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS) and some run options

--- a/tests/tools/vcs/2stage_minimal/Makefile
+++ b/tests/tools/vcs/2stage_minimal/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h
+design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS)

--- a/tests/tools/vcs/2stage_minimal/Makefile
+++ b/tests/tools/vcs/2stage_minimal/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv
+design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c c_header.h
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS)

--- a/tests/tools/vcs/2stage_minimal/Makefile
+++ b/tests/tools/vcs/2stage_minimal/Makefile
@@ -2,8 +2,8 @@
 
 all: design
 
-design: vlog_incfile sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h vcs.f parameters.txt
-	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp c_header.h c_header.h
+design: vlog_incfile c_header.h c_header.h sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp vcs.f parameters.txt
+	$(EDALIZE_LAUNCHER) vcs -full64 -o design -file vcs.f -parameters parameters.txt sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v another_sv_file.sv c_file.c cpp_file.cpp
 
 run:
 	$(EDALIZE_LAUNCHER) ./design $(EXTRA_OPTIONS)

--- a/tests/tools/vcs/basic/Makefile
+++ b/tests/tools/vcs/basic/Makefile
@@ -2,7 +2,7 @@
 
 all: custom_binary_name
 
-work.workdir/AN.DB/make.vlogan work.workdir/64/vhmra.sdb libx.workdir/64/vhmra.sdb: sv_file.sv vlog_incfile vlog_file.v vlog_incfile vlog_with_define.v vlog_incfile vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile work.f work_1.f work_2.f work_3.f work_4.f libx.f work_5.f work_6.f
+work.workdir/AN.DB/make.vlogan work.workdir/64/vhmra.sdb libx.workdir/64/vhmra.sdb: sv_file.sv vlog_incfile vlog_file.v vlog_incfile vlog_with_define.v vlog_incfile vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile c_header.h c_header.h work.f work_1.f work_2.f work_3.f work_4.f libx.f work_5.f work_6.f
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work.f -work work -l work.log sv_file.sv
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work_1.f -work work -l work_1.log vlog_file.v
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work_2.f -work work -l work_2.log vlog_with_define.v

--- a/tests/tools/vcs/basic/vcs.f
+++ b/tests/tools/vcs/basic/vcs.f
@@ -1,1 +1,1 @@
--top top_module some vcs options c_file.c c_header.h
+-top top_module some vcs options c_file.c cpp_file.cpp c_header.h c_header.h

--- a/tests/tools/vcs/basic/vcs.f
+++ b/tests/tools/vcs/basic/vcs.f
@@ -1,1 +1,1 @@
--top top_module some vcs options
+-top top_module some vcs options c_file.c c_header.h

--- a/tests/tools/vcs/basic/vcs.f
+++ b/tests/tools/vcs/basic/vcs.f
@@ -1,1 +1,1 @@
--top top_module some vcs options c_file.c cpp_file.cpp c_header.h c_header.h
+-top top_module some vcs options c_file.c cpp_file.cpp

--- a/tests/tools/vcs/minimal/Makefile
+++ b/tests/tools/vcs/minimal/Makefile
@@ -2,7 +2,7 @@
 
 all: design
 
-work.workdir/AN.DB/make.vlogan work.workdir/64/vhmra.sdb libx.workdir/64/vhmra.sdb: sv_file.sv vlog_incfile vlog_file.v vlog_incfile vlog_with_define.v vlog_incfile vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile work.f work_1.f work_2.f work_3.f work_4.f libx.f work_5.f work_6.f
+work.workdir/AN.DB/make.vlogan work.workdir/64/vhmra.sdb libx.workdir/64/vhmra.sdb: sv_file.sv vlog_incfile vlog_file.v vlog_incfile vlog_with_define.v vlog_incfile vlog05_file.v vlog_incfile vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile c_header.h c_header.h work.f work_1.f work_2.f work_3.f work_4.f libx.f work_5.f work_6.f
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work.f -work work -l work.log sv_file.sv
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work_1.f -work work -l work_1.log vlog_file.v
 	$(EDALIZE_LAUNCHER) vlogan -full64 -file work_2.f -work work -l work_2.log vlog_with_define.v

--- a/tests/tools/vcs/minimal/vcs.f
+++ b/tests/tools/vcs/minimal/vcs.f
@@ -1,1 +1,1 @@
--top top_module c_file.c c_header.h
+-top top_module c_file.c cpp_file.cpp c_header.h c_header.h

--- a/tests/tools/vcs/minimal/vcs.f
+++ b/tests/tools/vcs/minimal/vcs.f
@@ -1,1 +1,1 @@
--top top_module
+-top top_module c_file.c c_header.h

--- a/tests/tools/vcs/minimal/vcs.f
+++ b/tests/tools/vcs/minimal/vcs.f
@@ -1,1 +1,1 @@
--top top_module c_file.c cpp_file.cpp c_header.h c_header.h
+-top top_module c_file.c cpp_file.cpp


### PR DESCRIPTION
# Sim Flow VCS Tool -> Add C/C++ File Support

#503 

* Analyze edam files for cSource and cppSource typed files
* Insert into vcs.f for three step, add to makefile for two step 
* Modify VCS tool tests to include c/c++ source files