### PR TITLE
[doc] Flow name fixed

### DIFF
--- a/doc/ref/migrations.rst
+++ b/doc/ref/migrations.rst
@@ -55,7 +55,7 @@ For users that are using Edalize through FuseSoC, the `flow` and `flow_options` 
 
       #New Flow API
       targets:
-        fpga:
+        sim:
           flow : sim
           flow_options:
             tool : icarus


### PR DESCRIPTION
I think the name of the target and the flow should be the same here.