### PR TITLE
Add "generic" to the list of supported parameter types

### DIFF
--- a/edalize/flows/vivado.py
+++ b/edalize/flows/vivado.py
@@ -10,7 +10,7 @@ from edalize.flows.edaflow import Edaflow, FlowGraph
 class Vivado(Edaflow):
     """The Vivado flow executes AMD Vivado to create a bitstream and optionally program a board. Yosys can be used for synthesis by setting the synth option accordingly"""
 
-    argtypes = ["vlogdefine", "vlogparam"]
+    argtypes = ["vlogdefine", "vlogparam", "generic"]
 
     FLOW_DEFINED_TOOL_OPTIONS = {
         "yosys": {"arch": "xilinx", "output_format": "edif"},


### PR DESCRIPTION
It looks like the code to handle this is already present, as with this in place it generates the correct TCL to set the generics.

Without this change, FuseSoC cores using `flow: vivado` will print a warning for a each generic parameter for a given taget, and if an attempt is make to set that generic on the command line, the build will fail. With this change, the warnings are gone and CLI options to set generics are accepted and transformed into correct TCL, resulting in Vivado working as expected.

Fixes issue #515 
