### PR TITLE
Fix AttributeError in tools/vpr.py when EDAM contains an SDC file

### DIFF
--- a/edalize/tools/vpr.py
+++ b/edalize/tools/vpr.py
@@ -86,7 +86,7 @@ class Vpr(Edatool):
                     )
                 netlist_file = f["name"]
             if file_type in ["SDC"]:
-                timing_constraints.append(f.name)
+                timing_constraints.append(f["name"])
 
         arch_xml = self.tool_options.get("arch_xml")
         if not arch_xml:


### PR DESCRIPTION
Bug: `tools/vpr.py:89` accesses `f.name` on a dict, raising `AttributeError` when an SDC file is present. Fix is to use again `f["name"]` like lines 84 and 87.