### PR TITLE
flows/vpr: fix 'ftdo' typo to 'fdto'

### DIFF
--- a/edalize/flows/vpr.py
+++ b/edalize/flows/vpr.py
@@ -15,7 +15,7 @@ class Vpr(Edaflow):
     def configure_flow(self, flow_options):
 
         flow = {
-            "yosys": {"ftdo": {"output_format": "blif"}},
+            "yosys": {"fdto": {"output_format": "blif"}},
             "vpr": {"deps": ["yosys"]},
         }
         return FlowGraph.fromdict(flow)


### PR DESCRIPTION
The `ftdo` key in `flows/vpr.py`'s yosys flow node is silently dropped because `Edaflow` only recognises `fdto` (flow-defined tool options). As a result yosys is never told to emit BLIF output for the VPR flow.

One-character fix.