### PR TITLE
tools/sandpipersaas: pass dependency list to commands.add, not a string

### DIFF
--- a/edalize/tools/sandpipersaas.py
+++ b/edalize/tools/sandpipersaas.py
@@ -105,7 +105,7 @@ class Sandpipersaas(Edatool):
         commands.add([_gen_s], targets, deps)
         commands.add_env_var("RM", "rm -rf")
 
-        commands.add(["${RM} " + self.work_root], ["clean"], " ")
+        commands.add(["${RM} " + self.work_root], ["clean"], [])
         commands.set_default_target(output_file_path)
         self.commands = commands
 


### PR DESCRIPTION
The `clean` target was registered with `depends=" "` (a single-space string). `EdaCommands.add` expects a list of dependency names; the string is wrong and was never intentional.