### PR TITLE
tools/surelog: fix UnboundLocalError when vlogdefine is non-empty

### DIFF
--- a/edalize/tools/surelog.py
+++ b/edalize/tools/surelog.py
@@ -51,7 +51,7 @@ class Surelog(Edatool):
         # Handle verilog defines
         verilog_defines = []
         for key, value in self.vlogdefine.items():
-            verilog_params.append(f"+define+{key}={value}")
+            verilog_defines.append(f"+define+{key}={value}")
 
         # Handle verilog parameters
         verilog_params = []


### PR DESCRIPTION
The Verilog-defines loop appended to `verilog_params` instead of `verilog_defines`. `verilog_params` is not defined at that point (assigned a few lines later), so the loop raises `UnboundLocalError` whenever `self.vlogdefine` is non-empty.