### PR TITLE
tools/vivado: return local args from build(), not undefined self.args

### DIFF
--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -285,7 +285,7 @@ class Vivado(Edatool):
                 pass
             elif self.tool_options["pnr"] == "none":
                 args.append("synth")
-        return ("make", self.args, self.work_root)
+        return ("make", args, self.work_root)
 
     def run(self):
         """


### PR DESCRIPTION
`Vivado.build()` builds up a local `args` list but returns `self.args`, which is never assigned anywhere on the class. The fix is to return the local `args` that was just constructed.