### PR TITLE
tools/vpr: return empty args from build(), not undefined self.args

### DIFF
--- a/edalize/tools/vpr.py
+++ b/edalize/tools/vpr.py
@@ -174,4 +174,4 @@ class Vpr(Edatool):
 
     def build(self):
         logger.info("Building")
-        return ("make", self.args, self.work_root)
+        return ("make", [], self.work_root)


### PR DESCRIPTION
`Vpr.build()` returns `self.args`, which is never assigned. Unlike `Vivado.build()`, there is no local `args` to recover, so the fix is conservative: return an empty list. Happy to change if a different intent is preferred.