### PR TITLE
openfpga: forward eda_api and verbose to base ctor correctly

### DIFF
--- a/edalize/openfpga.py
+++ b/edalize/openfpga.py
@@ -61,7 +61,7 @@ class Openfpga(Edatool):
 
         - ``SOFA_PATH``: directory of the SOFA eFPGA IPs, available here: https://github.com/lnis-uofu/SOFA
         """
-        super(Openfpga, self).__init__(edam, work_root, verbose)
+        super(Openfpga, self).__init__(edam, work_root, eda_api, verbose)
 
         # Check environment variable setup
         if os.environ.get("OPENFPGA_PATH") is None:


### PR DESCRIPTION
`Edatool.__init__` takes `(edam, work_root, eda_api, verbose)`. `Openfpga.__init__` was calling `super().__init__(edam, work_root, verbose)`, which assigns `verbose` into the `eda_api` slot and drops the real `verbose` flag entirely.