### PR TITLE
slang: fix __init__ typo (def __init) and forward verbose to super

### DIFF
--- a/edalize/slang.py
+++ b/edalize/slang.py
@@ -36,9 +36,9 @@ Example snippet of a CAPI2 description file for Slang:
 
     flags = []
 
-    def __init(self, edam=None, work_root=None, eda_api=None):
+    def __init__(self, edam=None, work_root=None, eda_api=None, verbose=True):
         # call the super method here
-        super(Slang, self).__init__(edam, work_root, eda_api)
+        super(Slang, self).__init__(edam, work_root, eda_api, verbose)
 
         self.rtl_paths = None
         self.incdirs = None
@@ -48,8 +48,6 @@ Example snippet of a CAPI2 description file for Slang:
 
         # contain the command line arguments
         self.flags = []
-
-        return 0
 
     @staticmethod
     def get_doc(api_ver):

--- a/tests/test_slang.py
+++ b/tests/test_slang.py
@@ -1,6 +1,30 @@
 from .edalize_common import make_edalize_test
 
 
+def test_slang_constructor_runs(make_edalize_test):
+    # Regression for the ``def __init`` (note the missing trailing ``__``)
+    # typo: the constructor never fired, so the instance-level attributes
+    # below were never initialised and ``self.verbose`` was not propagated
+    # from the Edatool base class. Build the backend through the standard
+    # fixture and inspect the resulting instance.
+    tf = make_edalize_test(
+        "slang",
+        test_name="test_slang_constructor_runs",
+        tool_options={"mode": "lint"},
+        ref_dir="lint",
+    )
+    backend = tf.backend
+    assert backend.rtl_paths is None
+    assert backend.incdirs is None
+    assert backend.gen_rtl_name is None
+    # ``flags`` is per-instance (not the shared class attribute) once the
+    # constructor has fired.
+    assert backend.flags == []
+    assert backend.flags is not type(backend).flags
+    # ``verbose`` is forwarded through to Edatool by the constructor.
+    assert isinstance(backend.verbose, bool)
+
+
 def test_slang_lint(make_edalize_test):
     tool_options = {"mode": "lint"}
     tf = make_edalize_test(


### PR DESCRIPTION
## Summary

`Slang` declares its constructor as:

```python
def __init(self, edam=None, work_root=None, eda_api=None):
```

— note the **missing trailing `__`**. Python therefore never resolves
this method as `__init__`, the constructor never fires, and the
inherited `Edatool.__init__` runs instead.

Knock-on effects of the typo:

1. **`super().__init__` is never called from `Slang`.** This happens
   to work today only because `Edatool.__init__` is what Python ends
   up calling directly on the subclass — but the `Slang`-specific
   setup (the four `self.…` lines below the super call) is dead code
   on every instance.
2. **Instance attributes are not initialised.** `self.rtl_paths`,
   `self.incdirs`, `self.gen_rtl_name`, and the per-instance
   `self.flags` list are never set in `__init`. The class only works
   at all because `flags = []` exists as a *class* attribute, which
   means every `Slang` instance silently shares one list until
   `configure_main` reassigns `self.flags` per-instance.
3. **`return 0` would be a `TypeError`** the moment the constructor
   actually fires — `__init__` must return `None`.
4. **`verbose` is dropped.** Even ignoring the typo, the `super()`
   call was missing the `verbose` argument, mirroring the
   `openfpga` regression fixed in #524.

## Change

```diff
-    def __init(self, edam=None, work_root=None, eda_api=None):
+    def __init__(self, edam=None, work_root=None, eda_api=None, verbose=True):
         # call the super method here
-        super(Slang, self).__init__(edam, work_root, eda_api)
+        super(Slang, self).__init__(edam, work_root, eda_api, verbose)

         self.rtl_paths = None
         self.incdirs = None

         # path for final rtl generation
         self.gen_rtl_name = None

         # contain the command line arguments
         self.flags = []
-
-        return 0
```

## Test

Adds `test_slang_constructor_runs` to `tests/test_slang.py`. It builds
the backend via the existing `make_edalize_test` fixture and asserts:

- `backend.rtl_paths is None`
- `backend.incdirs is None`
- `backend.gen_rtl_name is None`
- `backend.flags == []` **and** `backend.flags is not type(backend).flags`
  (so the per-instance list is not the shared class attribute)
- `backend.verbose` is set (forwarded by the fixed super call)

```
$ pytest tests/test_slang.py -v
test_slang_constructor_runs   ... PASSED
test_slang_lint               ... PASSED
test_slang_preprocess         ... PASSED
test_slang_slang_options      ... PASSED
4 passed
```

## Related

PR #524 fixes the equivalent dropped-`verbose` bug for `openfpga`. The
typo here additionally hid that same bug in `Slang`.
