### PR TITLE
feat(xcelium): add the --gui option for Xcelium backend

### DIFF
--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -20,6 +20,7 @@ class Xcelium(Edatool):
         },
         "timescale": {"type": "str", "desc": "Default timescale for simulation"},
         "xrun_options": {"type": "str", "desc": "Additional run options for xrun"},
+        "gui": {"type": "bool", "desc": "Invoke the Graphical User Interface (GUI)"},
     }
 
     V_SRC_FILE_TYPES = ["verilogSource", "systemVerilogSource"]
@@ -183,6 +184,9 @@ class Xcelium(Edatool):
 
     def run(self):
         args = ["-R"]
+
+        if self.tool_options.get("gui"):
+            args += ["-gui"]
 
         # Set plusargs
         if self.plusarg:

--- a/tests/test_tool_xcelium.py
+++ b/tests/test_tool_xcelium.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .edalize_tool_common import tool_fixture
 
 
@@ -32,3 +34,24 @@ def test_tool_xcelium_minimal(tool_fixture):
             "xrun.f",
         ]
     )
+
+
+@pytest.mark.parametrize("gui", (None, False, True))
+def test_tool_xcelium_gui(tool_fixture, gui: bool | None) -> None:
+    """Test if the Xcelium backend will add the ``-gui`` option."""
+    tool_options = {}
+
+    if gui is not None:
+        tool_options["gui"] = gui
+
+    tf = tool_fixture("xcelium", tool_options=tool_options, paramtypes=[])
+
+    tf.tool.configure()
+    command, args, _ = tf.tool.run()
+
+    assert command == "xrun"
+
+    if gui:
+        assert "-gui" in args
+    else:
+        assert "-gui" not in args


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/528

PR adds the `--gui` option for the Xcelium backend that will allow to invoke the Graphical User Interface (GUI) of the Cadence Xcelium simulator.

Usage:

```plaintext
fusesoc run --target <xcelium-flow-target> <core> --gui
```

Added unit test:

```plaintext
pytest -k test_tool_xcelium_gui
```

Source files were also validated with the `pre-commit` (black):

```plaintext
pre-commit run --files ./edalize/tools/xcelium.py ./tests/test_tool_xcelium.py
```