### PR TITLE
fix(xcelium): TCL source files for xrun

### DIFF
--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -84,9 +84,9 @@ class Xcelium(Edatool):
         )
 
         # Append TCL scripts
-        tcl_cmd = []
+        self.tcl_cmd = []
         for tcl in tcl_files:
-            tcl_cmd += ["-input", tcl]
+            self.tcl_cmd += ["-input", tcl]
 
         # Append DPI libraries
         dpi_lib_cmd = []
@@ -167,7 +167,6 @@ class Xcelium(Edatool):
         self.xrun_f = (
             en_64bit_cmd
             + sv_cmd
-            + tcl_cmd
             + dpi_lib_cmd
             + macro_def_cmd
             + vlogparam_cmd
@@ -183,7 +182,7 @@ class Xcelium(Edatool):
         self.update_config_file("xrun.f", "\n".join(self.xrun_f) + "\n")
 
     def run(self):
-        args = ["-R"]
+        args = ["-R"] + self.tcl_cmd
 
         if self.tool_options.get("gui"):
             args += ["-gui"]

--- a/tests/test_tool_xcelium.py
+++ b/tests/test_tool_xcelium.py
@@ -22,6 +22,12 @@ def test_tool_xcelium(tool_fixture):
         ]
     )
 
+    cmd, args, _ = tf.tool.run()
+    assert cmd == "xrun"
+    assert "-R" in args
+    assert "-input" in args
+    assert args[args.index("-input") + 1] == "tcl_file.tcl"
+
 
 def test_tool_xcelium_minimal(tool_fixture):
     tf = tool_fixture("xcelium", tool_options={}, paramtypes=[], ref_subdir="minimal")
@@ -34,6 +40,12 @@ def test_tool_xcelium_minimal(tool_fixture):
             "xrun.f",
         ]
     )
+
+    cmd, args, _ = tf.tool.run()
+    assert cmd == "xrun"
+    assert "-R" in args
+    assert "-input" in args
+    assert args[args.index("-input") + 1] == "tcl_file.tcl"
 
 
 @pytest.mark.parametrize("gui", (None, False, True))

--- a/tests/tools/xcelium/minimal/xrun.f
+++ b/tests/tools/xcelium/minimal/xrun.f
@@ -1,7 +1,5 @@
 -64bit
 -sv
--input
-tcl_file.tcl
 +incdir+.
 -top
 top_module

--- a/tests/tools/xcelium/xrun.f
+++ b/tests/tools/xcelium/xrun.f
@@ -1,6 +1,4 @@
 -sv
--input
-tcl_file.tcl
 +define+vlogdefine_bool=1
 +define+vlogdefine_int=42
 +define+vlogdefine_str=""hello""


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/531

TCL source files must be added to xrun runtime stage not to compilation/elaborate stage.

Fixed and improved existing unit tests.

```plaintext
pytest -k test_tool_xcelium
```