### PR TITLE
fix(xcelium): handle xrun_options passed from FuseSoC command line

### DIFF
--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -19,7 +19,11 @@ class Xcelium(Edatool):
             "desc": "Disable 64-bit mode",
         },
         "timescale": {"type": "str", "desc": "Default timescale for simulation"},
-        "xrun_options": {"type": "str", "desc": "Additional run options for xrun"},
+        "xrun_options": {
+            "type": "str",
+            "desc": "Additional run options for xrun",
+            "list": True,
+        },
         "gui": {"type": "bool", "desc": "Invoke the Graphical User Interface (GUI)"},
     }
 


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/530

This PR:

* Fixes passing the `--xrun_options="<args>"` from the `fusesoc` command line interface to the Edalize `xcelium` backend

Correct way to enable handling list for an option: https://github.com/olofk/fusesoc/pull/791#issuecomment-4864705684