### PR TITLE
feat(xcelium): add support for VHDL-93, VHDL-2008, VHDL-2019, Verilog-1995, Verilog-2001

### DIFF
--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -27,6 +27,17 @@ class Xcelium(Edatool):
     TCL_SCRIPT_TYPES = ["tclSource"]
     DPIC_LIB_TYPES = ["dpiLibrary"]
 
+    #: Map file type to xrun argument that will enable particular Verilog or VHDL features
+    FILE_TYPE_TO_FEATURE_FLAG = {
+        "verilogSource-95": "-v1995",
+        "verilogSource-1995": "-v1995",
+        "verilogSource-2001": "-v2001",
+        "vhdlSource-93": "-v93",
+        "vhdlSource-1993": "-v93",
+        "vhdlSource-2008": "-v200x",
+        "vhdlSource-2019": "-v2019",
+    }
+
     def setup(self, edam):
         super().setup(edam)
 
@@ -38,7 +49,6 @@ class Xcelium(Edatool):
         src_files = []
         tcl_files = []
         dpi_libraries = []
-        has_system_verilog = False
 
         # Move different type of files to a separate list
         for f in self.files:
@@ -49,16 +59,17 @@ class Xcelium(Edatool):
             file_type = f.get("file_type", "")
 
             # Verilog source files
-            if file_type in self.V_SRC_FILE_TYPES:
+            if any(map(file_type.startswith, self.V_SRC_FILE_TYPES)):
                 if self._add_include_dir(f, incdirs, force_slash=True):
                     # This file is a include file
                     include_files.append(f["name"])
                 else:
-                    if file_type.startswith("systemVerilogSource"):
-                        has_system_verilog = True
-
                     # This file is a normal source file
                     src_files.append(f)
+                unused_files.remove(f)
+
+            if file_type.startswith("vhdlSource"):
+                src_files.append(f)
                 unused_files.remove(f)
 
             if file_type in self.TCL_SCRIPT_TYPES:
@@ -74,7 +85,6 @@ class Xcelium(Edatool):
 
         # Append option flags
         en_64bit_cmd = [] if self.tool_options.get("32bit") else ["-64bit"]
-        sv_cmd = ["-sv"] if has_system_verilog else []
 
         # Append timescale option
         timescale_cmd = (
@@ -120,7 +130,10 @@ class Xcelium(Edatool):
         # different file_type, logical_name or defines compared
         # to the previous file, we put it in a new file group
         for f in src_files:
-            lib = f.get("logical_name", "")
+            # The 'worklib' is the default library in Xcelium
+            # We need to use -makelib <library> <option>... <file>... -endlib to group files
+            # This is required to support compiling mixed-languages and mixed-standards altogether
+            lib = f.get("logical_name", "worklib")
             defines = f.get("define", {})
             file_type = f.get("file_type")
             fileopts = (file_type, lib, defines)
@@ -133,11 +146,15 @@ class Xcelium(Edatool):
         for fg in filegroups:
             # Ignore empty file groups
             if fg[1]:
-                (_, lib, defines) = fg[0]
+                (file_type, lib, defines) = fg[0]
                 if lib:
                     files_cmd += ["-makelib", lib]
                 for k, v in defines.items():
                     files_cmd += ["-define", f"{k}={v}"]
+                if file_type.startswith("systemVerilogSource"):
+                    files_cmd += ["-sv"]
+                if file_type in self.FILE_TYPE_TO_FEATURE_FLAG:
+                    files_cmd += [self.FILE_TYPE_TO_FEATURE_FLAG[file_type]]
                 files_cmd += fg[1]
                 if lib:
                     files_cmd += ["-endlib"]
@@ -166,7 +183,6 @@ class Xcelium(Edatool):
 
         self.xrun_f = (
             en_64bit_cmd
-            + sv_cmd
             + dpi_lib_cmd
             + macro_def_cmd
             + vlogparam_cmd

--- a/tests/tools/xcelium/Makefile
+++ b/tests/tools/xcelium/Makefile
@@ -2,5 +2,5 @@
 
 all: xcelium.d/run.d/hdl.var
 
-xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
-	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition sv_file.sv vlog_file.v -define FD_KEY=FD_VAL vlog_with_define.v another_sv_file.sv
+xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
+	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition -makelib worklib -sv sv_file.sv -endlib -makelib worklib vlog_file.v -endlib -makelib worklib -define FD_KEY=FD_VAL vlog_with_define.v -endlib -makelib worklib vlog05_file.v -endlib -makelib worklib vhdl_file.vhd -endlib -makelib libx vhdl_lfile -endlib -makelib worklib -v200x vhdl2008_file -endlib -makelib worklib -sv another_sv_file.sv -endlib

--- a/tests/tools/xcelium/minimal/Makefile
+++ b/tests/tools/xcelium/minimal/Makefile
@@ -2,5 +2,5 @@
 
 all: xcelium.d/run.d/hdl.var
 
-xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
-	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition sv_file.sv vlog_file.v -define FD_KEY=FD_VAL vlog_with_define.v another_sv_file.sv
+xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
+	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition -makelib worklib -sv sv_file.sv -endlib -makelib worklib vlog_file.v -endlib -makelib worklib -define FD_KEY=FD_VAL vlog_with_define.v -endlib -makelib worklib vlog05_file.v -endlib -makelib worklib vhdl_file.vhd -endlib -makelib libx vhdl_lfile -endlib -makelib worklib -v200x vhdl2008_file -endlib -makelib worklib -sv another_sv_file.sv -endlib

--- a/tests/tools/xcelium/minimal/xrun.f
+++ b/tests/tools/xcelium/minimal/xrun.f
@@ -1,5 +1,4 @@
 -64bit
--sv
 +incdir+.
 -top
 top_module

--- a/tests/tools/xcelium/xrun.f
+++ b/tests/tools/xcelium/xrun.f
@@ -1,4 +1,3 @@
--sv
 +define+vlogdefine_bool=1
 +define+vlogdefine_int=42
 +define+vlogdefine_str=""hello""


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/533 and closes https://github.com/olofk/edalize/issues/534

This PR:
- Adds support for VHDL in general. Only Verilog and SystemVerllog was supported
- Adds support for VHDL-93, VHDL-2008, VHDL-2019, Verilog-1995, Verilog-2001 standards
- Adds support for compiling mixed-languages and mixed-standards even when logical library was not set. The default library used by Xcelium is `worklib`
- Moving language feature flags like `-sv` or `-v2008` to file groups
- Updates unit tests for the Xcelium backend

Available feature flags in the Cadence Xcelium for reference:

```plaintext
xrun -helpall | grep -iE -- '-v[0-9]'
  -inc_v200x_pkg             Implicitly include -v200x packages
  -v1995                     Turn off new Verilog-2001 keywords
  -v2001                     Turn off new Verilog-2005 keywords
  -v200x                     Enable VHDL200X and VHDL93 features
  -v2019                     Enable VHDL2019, VHDL200X and VHDL93 features
  -v93                       Enable VHDL93 features
```