### PR TITLE
Close file handles with context managers

### DIFF
--- a/edalize/modelsim.py
+++ b/edalize/modelsim.py
@@ -106,134 +106,133 @@ class Modelsim(Edatool):
             }
 
     def _write_build_rtl_tcl_file(self, tcl_main):
-        tcl_build_rtl = open(os.path.join(self.work_root, "edalize_build_rtl.tcl"), "w")
+        with open(
+            os.path.join(self.work_root, "edalize_build_rtl.tcl"), "w"
+        ) as tcl_build_rtl:
 
-        (src_files, incdirs) = self._get_fileset_files()
-        vlog_include_dirs = ["+incdir+" + d.replace("\\", "/") for d in incdirs]
+            (src_files, incdirs) = self._get_fileset_files()
+            vlog_include_dirs = ["+incdir+" + d.replace("\\", "/") for d in incdirs]
 
-        libs = []
+            libs = []
 
-        vlog_files = []
+            vlog_files = []
 
-        common_compilation = self.tool_options.get("compilation_mode") == "common"
-        for f in src_files:
-            if not f.logical_name:
-                f.logical_name = "work"
-            if not f.logical_name in libs:
-                tcl_build_rtl.write("vlib {}\n".format(f.logical_name))
-                libs.append(f.logical_name)
-            if f.file_type.startswith("verilogSource") or f.file_type.startswith(
-                "systemVerilogSource"
-            ):
-                vlog_files.append(f)
-                cmd = "vlog"
-                args = []
+            common_compilation = self.tool_options.get("compilation_mode") == "common"
+            for f in src_files:
+                if not f.logical_name:
+                    f.logical_name = "work"
+                if not f.logical_name in libs:
+                    tcl_build_rtl.write("vlib {}\n".format(f.logical_name))
+                    libs.append(f.logical_name)
+                if f.file_type.startswith("verilogSource") or f.file_type.startswith(
+                    "systemVerilogSource"
+                ):
+                    vlog_files.append(f)
+                    cmd = "vlog"
+                    args = []
 
-                args += self.tool_options.get("vlog_options", [])
+                    args += self.tool_options.get("vlog_options", [])
 
+                    for k, v in self.vlogdefine.items():
+                        args += ["+define+{}={}".format(k, self._param_value_str(v))]
+
+                    if f.file_type.startswith("systemVerilogSource"):
+                        args += ["-sv"]
+                    args += vlog_include_dirs
+                elif f.file_type.startswith("vhdlSource"):
+                    cmd = "vcom"
+                    if f.file_type.endswith("-87"):
+                        args = ["-87"]
+                    if f.file_type.endswith("-93"):
+                        args = ["-93"]
+                    if f.file_type.endswith("-2008"):
+                        args = ["-2008"]
+                    else:
+                        args = []
+
+                    args += self.tool_options.get("vcom_options", [])
+
+                elif f.file_type == "tclSource":
+                    cmd = None
+                    tcl_main.write("do {}\n".format(f.name))
+                elif f.file_type == "user":
+                    cmd = None
+                else:
+                    _s = "{} has unknown file type '{}'"
+                    logger.warning(_s.format(f.name, f.file_type))
+                    cmd = None
+                if cmd and ((cmd != "vlog") or not common_compilation):
+                    args += ["-quiet"]
+                    args += ["-work", f.logical_name]
+                    args += [f.name.replace("\\", "/")]
+                    tcl_build_rtl.write("{} {}\n".format(cmd, " ".join(args)))
+            if common_compilation:
+                args = self.tool_options.get("vlog_options", [])
                 for k, v in self.vlogdefine.items():
                     args += ["+define+{}={}".format(k, self._param_value_str(v))]
 
-                if f.file_type.startswith("systemVerilogSource"):
+                _vlog_files = []
+                has_sv = False
+                for f in vlog_files:
+                    _vlog_files.append(f.name.replace("\\", "/"))
+                    if f.file_type.startswith("systemVerilogSource"):
+                        has_sv = True
+
+                if has_sv:
                     args += ["-sv"]
                 args += vlog_include_dirs
-            elif f.file_type.startswith("vhdlSource"):
-                cmd = "vcom"
-                if f.file_type.endswith("-87"):
-                    args = ["-87"]
-                if f.file_type.endswith("-93"):
-                    args = ["-93"]
-                if f.file_type.endswith("-2008"):
-                    args = ["-2008"]
-                else:
-                    args = []
-
-                args += self.tool_options.get("vcom_options", [])
-
-            elif f.file_type == "tclSource":
-                cmd = None
-                tcl_main.write("do {}\n".format(f.name))
-            elif f.file_type == "user":
-                cmd = None
-            else:
-                _s = "{} has unknown file type '{}'"
-                logger.warning(_s.format(f.name, f.file_type))
-                cmd = None
-            if cmd and ((cmd != "vlog") or not common_compilation):
                 args += ["-quiet"]
-                args += ["-work", f.logical_name]
-                args += [f.name.replace("\\", "/")]
-                tcl_build_rtl.write("{} {}\n".format(cmd, " ".join(args)))
-        if common_compilation:
-            args = self.tool_options.get("vlog_options", [])
-            for k, v in self.vlogdefine.items():
-                args += ["+define+{}={}".format(k, self._param_value_str(v))]
-
-            _vlog_files = []
-            has_sv = False
-            for f in vlog_files:
-                _vlog_files.append(f.name.replace("\\", "/"))
-                if f.file_type.startswith("systemVerilogSource"):
-                    has_sv = True
-
-            if has_sv:
-                args += ["-sv"]
-            args += vlog_include_dirs
-            args += ["-quiet"]
-            args += ["-work", "work"]
-            args += ["-mfcu"]
-            tcl_build_rtl.write(f"vlog {' '.join(args)} {' '.join(_vlog_files)}")
+                args += ["-work", "work"]
+                args += ["-mfcu"]
+                tcl_build_rtl.write(f"vlog {' '.join(args)} {' '.join(_vlog_files)}")
 
     def _write_makefile(self):
-        vpi_make = open(os.path.join(self.work_root, "Makefile"), "w")
-        _parameters = []
-        for key, value in self.vlogparam.items():
-            _parameters += ["{}={}".format(key, self._param_value_str(value))]
-        for key, value in self.generic.items():
-            _parameters += [
-                "{}={}".format(key, self._param_value_str(value, bool_is_str=True))
-            ]
-        _plusargs = []
-        for key, value in self.plusarg.items():
-            _plusargs += ["{}={}".format(key, self._param_value_str(value))]
+        with open(os.path.join(self.work_root, "Makefile"), "w") as vpi_make:
+            _parameters = []
+            for key, value in self.vlogparam.items():
+                _parameters += ["{}={}".format(key, self._param_value_str(value))]
+            for key, value in self.generic.items():
+                _parameters += [
+                    "{}={}".format(key, self._param_value_str(value, bool_is_str=True))
+                ]
+            _plusargs = []
+            for key, value in self.plusarg.items():
+                _plusargs += ["{}={}".format(key, self._param_value_str(value))]
 
-        _vsim_options = self.tool_options.get("vsim_options", [])
+            _vsim_options = self.tool_options.get("vsim_options", [])
 
-        _modules = [m["name"] for m in self.vpi_modules]
-        _clean_targets = " ".join(["clean_" + m for m in _modules])
-        _s = MAKE_HEADER.format(
-            toplevel=self.toplevel,
-            parameters=" ".join(_parameters),
-            plusargs=" ".join(_plusargs),
-            vsim_options=" ".join(_vsim_options),
-            modules=" ".join(_modules),
-            clean_targets=_clean_targets,
-        )
-        vpi_make.write(_s)
-
-        for vpi_module in self.vpi_modules:
-            _name = vpi_module["name"]
-            _objs = [os.path.splitext(s)[0] + ".o" for s in vpi_module["src_files"]]
-            _libs = ["-l" + l for l in vpi_module["libs"]]
-            _incs = ["-I" + d for d in vpi_module["include_dirs"]]
-            _s = VPI_MAKE_SECTION.format(
-                name=_name,
-                objs=" ".join(_objs),
-                libs=" ".join(_libs),
-                incs=" ".join(_incs),
+            _modules = [m["name"] for m in self.vpi_modules]
+            _clean_targets = " ".join(["clean_" + m for m in _modules])
+            _s = MAKE_HEADER.format(
+                toplevel=self.toplevel,
+                parameters=" ".join(_parameters),
+                plusargs=" ".join(_plusargs),
+                vsim_options=" ".join(_vsim_options),
+                modules=" ".join(_modules),
+                clean_targets=_clean_targets,
             )
             vpi_make.write(_s)
 
-        vpi_make.close()
+            for vpi_module in self.vpi_modules:
+                _name = vpi_module["name"]
+                _objs = [os.path.splitext(s)[0] + ".o" for s in vpi_module["src_files"]]
+                _libs = ["-l" + l for l in vpi_module["libs"]]
+                _incs = ["-I" + d for d in vpi_module["include_dirs"]]
+                _s = VPI_MAKE_SECTION.format(
+                    name=_name,
+                    objs=" ".join(_objs),
+                    libs=" ".join(_libs),
+                    incs=" ".join(_incs),
+                )
+                vpi_make.write(_s)
 
     def configure_main(self):
-        tcl_main = open(os.path.join(self.work_root, "edalize_main.tcl"), "w")
-        tcl_main.write("onerror { quit -code 1; }\n")
-        tcl_main.write("do edalize_build_rtl.tcl\n")
+        with open(os.path.join(self.work_root, "edalize_main.tcl"), "w") as tcl_main:
+            tcl_main.write("onerror { quit -code 1; }\n")
+            tcl_main.write("do edalize_build_rtl.tcl\n")
 
-        self._write_build_rtl_tcl_file(tcl_main)
+            self._write_build_rtl_tcl_file(tcl_main)
         self._write_makefile()
-        tcl_main.close()
 
     def run_main(self):
         args = ["run"]

--- a/edalize/questaformal.py
+++ b/edalize/questaformal.py
@@ -78,119 +78,123 @@ class Questaformal(Edatool):
             }
 
     def _write_build_rtl_tcl_file(self, tcl_main):
-        tcl_build_rtl = open(os.path.join(self.work_root, "edalize_build_rtl.tcl"), "w")
+        with open(
+            os.path.join(self.work_root, "edalize_build_rtl.tcl"), "w"
+        ) as tcl_build_rtl:
 
-        (src_files, incdirs) = self._get_fileset_files()
-        vlog_include_dirs = ["+incdir+" + d.replace("\\", "/") for d in incdirs]
+            (src_files, incdirs) = self._get_fileset_files()
+            vlog_include_dirs = ["+incdir+" + d.replace("\\", "/") for d in incdirs]
 
-        libs = []
-        for f in src_files:
-            if not f.logical_name:
-                f.logical_name = "work"
-            if not f.logical_name in libs:
-                tcl_build_rtl.write("vlib {}\n".format(f.logical_name))
-                libs.append(f.logical_name)
-            if f.file_type.startswith("verilogSource") or f.file_type.startswith(
-                "systemVerilogSource"
-            ):
-                cmd = "vlog"
-                args = []
-
-                args += self.tool_options.get("vlog_options", [])
-
-                for k, v in self.vlogdefine.items():
-                    args += ["+define+{}={}".format(k, self._param_value_str(v))]
-
-                if f.file_type.startswith("systemVerilogSource"):
-                    args += ["-sv"]
-                args += vlog_include_dirs
-            elif f.file_type.startswith("vhdlSource"):
-                cmd = "vcom"
-                if f.file_type.endswith("-87"):
-                    args = ["-87"]
-                if f.file_type.endswith("-93"):
-                    args = ["-93"]
-                if f.file_type.endswith("-2008"):
-                    args = ["-2008"]
-                else:
+            libs = []
+            for f in src_files:
+                if not f.logical_name:
+                    f.logical_name = "work"
+                if not f.logical_name in libs:
+                    tcl_build_rtl.write("vlib {}\n".format(f.logical_name))
+                    libs.append(f.logical_name)
+                if f.file_type.startswith("verilogSource") or f.file_type.startswith(
+                    "systemVerilogSource"
+                ):
+                    cmd = "vlog"
                     args = []
 
-                args += self.tool_options.get("vcom_options", [])
+                    args += self.tool_options.get("vlog_options", [])
 
-            elif f.file_type == "tclSource":
-                cmd = None
-                tcl_main.write("do {}\n".format(f.name))
-            elif f.file_type == "user":
-                cmd = None
-            else:
-                _s = "{} has unknown file type '{}'"
-                logger.warning(_s.format(f.name, f.file_type))
-                cmd = None
-            if cmd:
-                args += ["-quiet"]
-                args += ["-work", f.logical_name]
-                args += [f.name.replace("\\", "/")]
-                tcl_build_rtl.write("{} {}\n".format(cmd, " ".join(args)))
+                    for k, v in self.vlogdefine.items():
+                        args += ["+define+{}={}".format(k, self._param_value_str(v))]
+
+                    if f.file_type.startswith("systemVerilogSource"):
+                        args += ["-sv"]
+                    args += vlog_include_dirs
+                elif f.file_type.startswith("vhdlSource"):
+                    cmd = "vcom"
+                    if f.file_type.endswith("-87"):
+                        args = ["-87"]
+                    if f.file_type.endswith("-93"):
+                        args = ["-93"]
+                    if f.file_type.endswith("-2008"):
+                        args = ["-2008"]
+                    else:
+                        args = []
+
+                    args += self.tool_options.get("vcom_options", [])
+
+                elif f.file_type == "tclSource":
+                    cmd = None
+                    tcl_main.write("do {}\n".format(f.name))
+                elif f.file_type == "user":
+                    cmd = None
+                else:
+                    _s = "{} has unknown file type '{}'"
+                    logger.warning(_s.format(f.name, f.file_type))
+                    cmd = None
+                if cmd:
+                    args += ["-quiet"]
+                    args += ["-work", f.logical_name]
+                    args += [f.name.replace("\\", "/")]
+                    tcl_build_rtl.write("{} {}\n".format(cmd, " ".join(args)))
 
     def _write_makefile(self):
-        vpi_make = open(os.path.join(self.work_root, "Makefile"), "w")
-        _parameters = []
-        for key, value in self.vlogparam.items():
-            _parameters += ["{}={}".format(key, self._param_value_str(value))]
-        for key, value in self.generic.items():
-            _parameters += [
-                "{}={}".format(key, self._param_value_str(value, bool_is_str=True))
-            ]
-        _plusargs = []
-        for key, value in self.plusarg.items():
-            _plusargs += ["{}={}".format(key, self._param_value_str(value))]
+        with open(os.path.join(self.work_root, "Makefile"), "w") as vpi_make:
+            _parameters = []
+            for key, value in self.vlogparam.items():
+                _parameters += ["{}={}".format(key, self._param_value_str(value))]
+            for key, value in self.generic.items():
+                _parameters += [
+                    "{}={}".format(key, self._param_value_str(value, bool_is_str=True))
+                ]
+            _plusargs = []
+            for key, value in self.plusarg.items():
+                _plusargs += ["{}={}".format(key, self._param_value_str(value))]
 
-        _qverify_options = self.tool_options.get("qverify_options", [])
+            _qverify_options = self.tool_options.get("qverify_options", [])
 
-        _modules = [m["name"] for m in self.vpi_modules]
-        _clean_targets = " ".join(["clean_" + m for m in _modules])
-        _s = MAKE_HEADER.format(
-            toplevel=self.toplevel,
-            parameters=" ".join(_parameters),
-            plusargs=" ".join(_plusargs),
-            qverify_options=" ".join(_qverify_options),
-            modules=" ".join(_modules),
-            clean_targets=_clean_targets,
-        )
-        vpi_make.write(_s)
-
-        for vpi_module in self.vpi_modules:
-            _name = vpi_module["name"]
-            _objs = [os.path.splitext(s)[0] + ".o" for s in vpi_module["src_files"]]
-            _libs = ["-l" + l for l in vpi_module["libs"]]
-            _incs = ["-I" + d for d in vpi_module["include_dirs"]]
-            _s = VPI_MAKE_SECTION.format(
-                name=_name,
-                objs=" ".join(_objs),
-                libs=" ".join(_libs),
-                incs=" ".join(_incs),
+            _modules = [m["name"] for m in self.vpi_modules]
+            _clean_targets = " ".join(["clean_" + m for m in _modules])
+            _s = MAKE_HEADER.format(
+                toplevel=self.toplevel,
+                parameters=" ".join(_parameters),
+                plusargs=" ".join(_plusargs),
+                qverify_options=" ".join(_qverify_options),
+                modules=" ".join(_modules),
+                clean_targets=_clean_targets,
             )
             vpi_make.write(_s)
 
-        vpi_make.close()
+            for vpi_module in self.vpi_modules:
+                _name = vpi_module["name"]
+                _objs = [os.path.splitext(s)[0] + ".o" for s in vpi_module["src_files"]]
+                _libs = ["-l" + l for l in vpi_module["libs"]]
+                _incs = ["-I" + d for d in vpi_module["include_dirs"]]
+                _s = VPI_MAKE_SECTION.format(
+                    name=_name,
+                    objs=" ".join(_objs),
+                    libs=" ".join(_libs),
+                    incs=" ".join(_incs),
+                )
+                vpi_make.write(_s)
 
     def configure_main(self):
-        tcl_main = open(os.path.join(self.work_root, "edalize_main.tcl"), "w")
-        tcl_main.write("onerror { quit -code 1; }\n")
-        tcl_main.write("do edalize_build_rtl.tcl\n")
+        with open(
+            os.path.join(self.work_root, "edalize_autocheck.tcl"), "w"
+        ) as tcl_autocheck:
+            _autocheck_options = self.tool_options.get(
+                "autocheck_options",
+                [
+                    "enable",
+                    "compile -d {}".format(self.toplevel),
+                    "verify -timeout 10m",
+                ],
+            )
+            for ac_option in _autocheck_options:
+                tcl_autocheck.write("autocheck {}\n".format(ac_option))
 
-        tcl_autocheck = open(os.path.join(self.work_root, "edalize_autocheck.tcl"), "w")
-        _autocheck_options = self.tool_options.get(
-            "autocheck_options",
-            ["enable", "compile -d {}".format(self.toplevel), "verify -timeout 10m"],
-        )
-        for ac_option in _autocheck_options:
-            tcl_autocheck.write("autocheck {}\n".format(ac_option))
-        tcl_autocheck.close()
+        with open(os.path.join(self.work_root, "edalize_main.tcl"), "w") as tcl_main:
+            tcl_main.write("onerror { quit -code 1; }\n")
+            tcl_main.write("do edalize_build_rtl.tcl\n")
 
-        self._write_build_rtl_tcl_file(tcl_main)
+            self._write_build_rtl_tcl_file(tcl_main)
         self._write_makefile()
-        tcl_main.close()
 
     def run_main(self):
         args = ["run"]

--- a/edalize/reporting.py
+++ b/edalize/reporting.py
@@ -290,7 +290,8 @@ class Reporting(abc.ABC):
         :rtype: dict
         """
 
-        report = open(report_file, "r", encoding=cls._report_encoding).read()
+        with open(report_file, "r", encoding=cls._report_encoding) as f:
+            report = f.read()
 
         tables = {}
         for k, v in parser(report).items():

--- a/edalize/tools/edatool.py
+++ b/edalize/tools/edatool.py
@@ -101,7 +101,8 @@ class Edatool(object):
         """
         f = os.path.join(self.work_root, file_name)
         if os.path.exists(f):
-            old_file = open(f, "r").read()
+            with open(f, "r") as _f:
+                old_file = _f.read()
         else:
             old_file = None
         if old_file != contents:


### PR DESCRIPTION
The modelsim and questaformal backends open their generated `.tcl` and `Makefile` outputs without closing them (`_write_build_rtl_tcl_file` never closes; the others close but not exception-safely), which shows up as `ResourceWarning`s when running the test suite. `reporting.py` and `tools/edatool.py` leak read handles the same way (`open(...).read()`).

This converts all of them to `with` context managers. The diff in modelsim/questaformal looks large but is almost entirely re-indentation of the method bodies under the `with` block — no functional change.

Verified: full test suite passes with `-W error::ResourceWarning` (204 passed), and the golden-file tests confirm generated output is unchanged. Formatted with black 22.3.0.