### PR TITLE
flows: support env vars in hook scripts

### DIFF
--- a/edalize/flows/edaflow.py
+++ b/edalize/flows/edaflow.py
@@ -270,14 +270,11 @@ class Edaflow(object):
         hooks = self.edam.get("hooks", {})
         for script in hooks.get(hook_name, []):
 
-            # _env = self.env.copy()
-            # if 'env' in script:
-            #    _env.update(script['env'])
-
             targets = script["name"]
             command = script["cmd"]
-            # FIXME : Add env vars
-            self.commands.add(command, [targets], [last_script])
+            self.commands.add(
+                command, [targets], [last_script], variables=script.get("env", {})
+            )
 
             last_script = script["name"]
         self.commands.add([], [hook_name], [last_script])

--- a/tests/test_flow_hooks.py
+++ b/tests/test_flow_hooks.py
@@ -1,0 +1,27 @@
+from .edalize_common import FILES, param_gen
+from .edalize_flow_common import get_flow
+
+
+def test_hook_env(tmp_path):
+    edam = {
+        "name": "design",
+        "files": FILES,
+        "parameters": param_gen(["plusarg", "vlogdefine", "vlogparam"]),
+        "flow_options": {"tool": "icarus"},
+        "toplevel": "top_module",
+        "hooks": {
+            "pre_build": [
+                {
+                    "name": "sample_pre_build",
+                    "cmd": ["echo", "hello"],
+                    "env": {"FOO": "bar"},
+                }
+            ]
+        },
+    }
+
+    flow = get_flow("sim")(edam, tmp_path)
+    flow.configure()
+
+    makefile = (tmp_path / "Makefile").read_text()
+    assert "env FOO=bar echo hello" in makefile


### PR DESCRIPTION
The flow API silently drops the `env` key of EDAM hook scripts — `Edaflow.add_scripts()` has the support commented out with a `# FIXME : Add env vars` marker, while the legacy tool API honors `env` in `_run_scripts()`.

`EdaCommands.Command` already has a `variables` mechanism that the make build runner turns into an `env KEY=value` command prefix, so this just passes `script.get("env", {})` through it and removes the FIXME and the commented-out code.

Includes a test verifying that a `pre_build` hook with `env: {FOO: bar}` produces `env FOO=bar echo hello` in the generated Makefile (205 tests pass).