### PR TITLE
flows: properly merge EDAM from multiple dependencies

### DIFF
--- a/edalize/flows/edaflow.py
+++ b/edalize/flows/edaflow.py
@@ -72,6 +72,29 @@ def merge_dict(d1, d2):
     return d1
 
 
+def merge_edam(a, b):
+    """Merge two EDAM dicts coming from different flow graph dependencies.
+
+    Dicts are merged recursively and scalar values from the second EDAM
+    win. Lists are concatenated, but entries from the second EDAM that
+    already exist in the first one are skipped, so that files, hooks etc.
+    inherited from a common ancestor node don't show up once per
+    dependency. Neither input is modified.
+    """
+
+    def _merge(x, y):
+        if isinstance(x, dict) and isinstance(y, dict):
+            merged = dict(x)
+            for key, value in y.items():
+                merged[key] = _merge(merged[key], value) if key in merged else value
+            return merged
+        if isinstance(x, list) and isinstance(y, list):
+            return x + [e for e in y if e not in x]
+        return y
+
+    return _merge(a, b)
+
+
 class Node(object):
     def __init__(self, name, deps=[], fdto={}, tool=None):
         self.deps = deps
@@ -225,10 +248,6 @@ class Edaflow(object):
             self.edam["tool_options"] = tool_options
 
     def configure_tools(self, graph):
-        def merge_edam(a, b):
-            # Yeah, I know. It's just a temporary hack
-            return b
-
         # Instantiate each node and add to list of unconfigured nodes
         unconfigured_nodes = list(graph.get_nodes().values())
 

--- a/tests/test_flow_merge_edam.py
+++ b/tests/test_flow_merge_edam.py
@@ -1,0 +1,45 @@
+from edalize.flows.edaflow import merge_edam
+
+
+def test_merge_edam():
+    common = [{"name": "common.v", "file_type": "verilogSource"}]
+    a = {
+        "name": "design",
+        "files": common + [{"name": "a.v", "file_type": "verilogSource"}],
+        "hooks": {"pre_build": [{"name": "s", "cmd": ["true"]}]},
+        "tool_options": {"toola": {"opt": ["x"]}},
+        "toplevel": "top",
+    }
+    b = {
+        "name": "design",
+        "files": common + [{"name": "b.v", "file_type": "verilogSource"}],
+        "hooks": {"pre_build": [{"name": "s", "cmd": ["true"]}]},
+        "tool_options": {"toolb": {"opt": ["y"]}},
+        "toplevel": "top",
+    }
+
+    merged = merge_edam(a, b)
+
+    # Files inherited from a common ancestor only appear once
+    assert [f["name"] for f in merged["files"]] == ["common.v", "a.v", "b.v"]
+    assert merged["hooks"]["pre_build"] == [{"name": "s", "cmd": ["true"]}]
+    # Dicts are merged recursively
+    assert merged["tool_options"] == {
+        "toola": {"opt": ["x"]},
+        "toolb": {"opt": ["y"]},
+    }
+    assert merged["name"] == "design"
+    assert merged["toplevel"] == "top"
+
+    # Inputs are not modified
+    assert [f["name"] for f in a["files"]] == ["common.v", "a.v"]
+    assert [f["name"] for f in b["files"]] == ["common.v", "b.v"]
+
+
+def test_merge_edam_scalar_conflict():
+    assert merge_edam({"toplevel": "a"}, {"toplevel": "b"})["toplevel"] == "b"
+
+
+def test_merge_edam_empty():
+    edam = {"name": "design", "files": [{"name": "a.v"}]}
+    assert merge_edam({}, edam) == edam


### PR DESCRIPTION
In `Edaflow.configure_tools()`, the nested `merge_edam()` is a placeholder that just returns its second argument ("Yeah, I know. It's just a temporary hack"). For a fan-in node — one with more than one dependency — the input EDAM is whichever dependency was merged last, silently dropping the files, hooks and tool options contributed by the other dependencies.

This replaces the hack with a real merge, promoted to a module-level `merge_edam()` so it is unit-testable:

- dicts merge recursively; scalar conflicts resolve to the later dependency
- lists concatenate, skipping entries that already exist in the earlier list — files/hooks inherited from a common ancestor node appear once instead of once per dependency
- neither input EDAM is mutated

Single-dependency nodes receive the same content as before (the merge of `{}` with the dep's EDAM). Unit tests included; full suite passes (207 passed).