### PR TITLE
ci: update deprecated actions and test claimed Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
     - name: 🧰 Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🐍 Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -37,6 +37,7 @@ jobs:
         #- { icon: 🍎, name: macos }
         #- { icon: 🧊, name: windows }
         pyver:
+        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
@@ -47,10 +48,10 @@ jobs:
     steps:
 
     - name: 🧰 Repository Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: 🐍 Set up Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.pyver }}
 

--- a/tests/test_tool_xcelium.py
+++ b/tests/test_tool_xcelium.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from .edalize_tool_common import tool_fixture


### PR DESCRIPTION
Two CI health fixes:

- **Deprecated actions:** the Build job used `actions/checkout@v2` and `actions/setup-python@v1`, which run on Node.js versions GitHub has deprecated on current runners (the Format job was on v3). All checkout/setup-python steps are bumped to the current majors (v4/v5).
- **Untested Python 3.9:** `pyproject.toml` declares `requires-python = ">=3.9"` and carries the `importlib_metadata` backport dependency specifically for 3.9, but the CI matrix only tested 3.10–3.14. This adds 3.9 to the matrix so the claimed lower bound is actually exercised. (If 3.9 is no longer worth supporting, the alternative is bumping `requires-python` to `>=3.10` and dropping the backport shim — happy to rework the PR that way instead.)

Deliberately *not* included: bumping the black pre-commit pin (22.3.0). Every newer black release reformats existing files (black 24.x touches 8 files, 26.x touches 45), so that's better done as a standalone reformat commit to keep other PRs conflict-free.