### PR TITLE
fix(xcelium): handling DPI libraries

### DIFF
--- a/edalize/tools/xcelium.py
+++ b/edalize/tools/xcelium.py
@@ -99,9 +99,9 @@ class Xcelium(Edatool):
             self.tcl_cmd += ["-input", tcl]
 
         # Append DPI libraries
-        dpi_lib_cmd = []
+        self.dpi_lib_cmd = []
         for lib in dpi_libraries:
-            dpi_lib_cmd.append(["-sv_lib", lib])
+            self.dpi_lib_cmd.extend(("-sv_lib", lib))
 
         # Append macro definitions
         macro_def_cmd = []
@@ -183,7 +183,6 @@ class Xcelium(Edatool):
 
         self.xrun_f = (
             en_64bit_cmd
-            + dpi_lib_cmd
             + macro_def_cmd
             + vlogparam_cmd
             + incdir_cmd
@@ -198,7 +197,7 @@ class Xcelium(Edatool):
         self.update_config_file("xrun.f", "\n".join(self.xrun_f) + "\n")
 
     def run(self):
-        args = ["-R"] + self.tcl_cmd
+        args = ["-R"] + self.dpi_lib_cmd + self.tcl_cmd
 
         if self.tool_options.get("gui"):
             args += ["-gui"]

--- a/tests/edalize_common.py
+++ b/tests/edalize_common.py
@@ -244,6 +244,7 @@ FILES = [
     {"name": "qsf_constraint_file.qsf", "file_type": "QSF"},
     {"name": "pdc_floorplan_constraint_file.pdc", "file_type": "FPPDC"},
     {"name": "lpf_file.lpf", "file_type": "LPF"},
+    {"name": "libdpi.so", "file_type": "dpiLibrary"},
 ]
 """Files of all supported file types."""
 

--- a/tests/test_tool_xcelium.py
+++ b/tests/test_tool_xcelium.py
@@ -27,6 +27,8 @@ def test_tool_xcelium(tool_fixture):
     assert "-R" in args
     assert "-input" in args
     assert args[args.index("-input") + 1] == "tcl_file.tcl"
+    assert "-sv_lib" in args
+    assert args[args.index("-sv_lib") + 1] == "libdpi.so"
 
 
 def test_tool_xcelium_minimal(tool_fixture):
@@ -46,6 +48,8 @@ def test_tool_xcelium_minimal(tool_fixture):
     assert "-R" in args
     assert "-input" in args
     assert args[args.index("-input") + 1] == "tcl_file.tcl"
+    assert "-sv_lib" in args
+    assert args[args.index("-sv_lib") + 1] == "libdpi.so"
 
 
 @pytest.mark.parametrize("gui", (None, False, True))

--- a/tests/test_xcelium/Makefile
+++ b/tests/test_xcelium/Makefile
@@ -21,7 +21,7 @@ INCS := -I$(XCELIUM_HOME)/tools/include
 XRUN ?= $(XCELIUM_HOME)/tools/bin/xrun
 
 TOPLEVEL      := top_module
-DPI_LIBRARIES := -sv_lib libdpi1.so -sv_lib libdpi2.so
+DPI_LIBRARIES := -sv_lib libdpi.so -sv_lib libdpi1.so -sv_lib libdpi2.so
 PARAMETERS    ?= vlogparam_bool=1 vlogparam_int=42 vlogparam_str=hello
 PLUSARGS      ?= plusarg_bool=1 plusarg_int=42 plusarg_str=hello
 XMSIM_OPTIONS ?= a few xmsim_options

--- a/tests/test_xcelium/xrun.cmd
+++ b/tests/test_xcelium/xrun.cmd
@@ -1,1 +1,1 @@
--q -f edalize_main.f plenty of xrun_options -sv_lib libdpi1.so -sv_lib libdpi2.so -xmsimargs 'a few xmsim_options' -defparam vlogparam_bool=1 -defparam vlogparam_int=42 -defparam vlogparam_str=hello +plusarg_bool=1 +plusarg_int=42 +plusarg_str=hello -top top_module
+-q -f edalize_main.f plenty of xrun_options -sv_lib libdpi.so -sv_lib libdpi1.so -sv_lib libdpi2.so -xmsimargs 'a few xmsim_options' -defparam vlogparam_bool=1 -defparam vlogparam_int=42 -defparam vlogparam_str=hello +plusarg_bool=1 +plusarg_int=42 +plusarg_str=hello -top top_module

--- a/tests/tools/xcelium/Makefile
+++ b/tests/tools/xcelium/Makefile
@@ -2,5 +2,5 @@
 
 all: xcelium.d/run.d/hdl.var
 
-xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
+xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl libdpi.so xrun.f
 	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition -makelib worklib -sv sv_file.sv -endlib -makelib worklib vlog_file.v -endlib -makelib worklib -define FD_KEY=FD_VAL vlog_with_define.v -endlib -makelib worklib vlog05_file.v -endlib -makelib worklib vhdl_file.vhd -endlib -makelib libx vhdl_lfile -endlib -makelib worklib -v200x vhdl2008_file -endlib -makelib worklib -sv another_sv_file.sv -endlib

--- a/tests/tools/xcelium/minimal/Makefile
+++ b/tests/tools/xcelium/minimal/Makefile
@@ -2,5 +2,5 @@
 
 all: xcelium.d/run.d/hdl.var
 
-xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl xrun.f
+xcelium.d/run.d/hdl.var: sv_file.sv vlog_file.v vlog_with_define.v vlog05_file.v vhdl_file.vhd vhdl_lfile vhdl2008_file another_sv_file.sv vlog_incfile tcl_file.tcl libdpi.so xrun.f
 	$(EDALIZE_LAUNCHER) xrun -elaborate -f xrun.f -enable_cmdline_define_redefinition -makelib worklib -sv sv_file.sv -endlib -makelib worklib vlog_file.v -endlib -makelib worklib -define FD_KEY=FD_VAL vlog_with_define.v -endlib -makelib worklib vlog05_file.v -endlib -makelib worklib vhdl_file.vhd -endlib -makelib libx vhdl_lfile -endlib -makelib worklib -v200x vhdl2008_file -endlib -makelib worklib -sv another_sv_file.sv -endlib


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/548

The `xrun` command is just a wrapper to invoke:

* `xmvhdl` to compile VHDL source files
* `xmvlog` to compile Verilog and SystemVerilog source files
* `xmelab` to perform elaboration of HDL module
* `xmsim` to run simulation

Handling DPI libraries is only done by the `xmsim` command (simulation runtime):

```plaintext
xmsim -help | grep -i dpi
        -DPI_STACK_INT_C                    -- Lists internal C stack frames called from import function
        -SV_LIB <arg>                       -- Dynamically load a DPI Library
```

The elaboration stage is only used to generate header files for export/import functions/tasks:

```plaintext
xmelab | grep -i dpi
        -DPI_VOID_TASK                          -- Return value of export and import tasks will be VOID. 
        -DPIHEADER <arg>                        -- generate the header file for export functions/tasks
        -DPIIMPHEADER <arg>                     -- generate the header file for import functions/tasks
        -GCC_VERS <arg>                         -- Pass gcc_vers switch for DPI file compilation
```

DPI libraries `lib<name>.so` can be passed only to the simulation runtime stage:

```plaintext
xmsim -sv_lib <dir>/lib<name>.so
```

Without it, `xsim` (or `xrun -R`) will raise an error `NOFDPI`:

```plaintext
xmsim: *F,NOFDPI (<file>.sv,<line>|<column>): Function <name> not found in any of the shared object specified with -SV_LIB switch. The corresponding import DPI declaration is done in file <file>.sv at line no. <line>.
```

About the raised error:

```plaintext
xmhelp xmsim NOFDPI

xmsim/NOFDPI =
        C function declared in import DPI declaration should be present in
        shared library. Specified function is not available in any of the
        provided shared objects or default "libdpi".
        (Default severity: 'F')

        See more info at: https://support.cadence.com/apex/Coveo_CommunitySearch#ph=Xcelium&t=PlatformProductPage&oMenu=Search&cadproduct=%22Xcelium%22&q=NOFDPI
```

This PR:

* Fixed handling DPI libraries
* DPI libraries are passed to the simulation runtime stage `xrun -R` (aka `xmsim`)
* Removes DPI libraries from elaboration stage. They where ignored by the `xrun` elaboration stage
* DPI libraries were composed as list of list (`dpi_lib_cmd`) and concatenated with xrun arguments generating invalid arguments at the end `['-sv_lib', 'libdpi.so']`
* Adds additional `libdpi.so` file for test fixture (and fixes legacy xcelium tests because of that...)
* Extends `test_tool_xcelium` to check if the `xrun -R` simulation command contains DPI arguments `-sv_dpi libdpi.so`