### PR TITLE
fix(vivado): property usage for simulation files

### DIFF
--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -150,10 +150,7 @@ class Vivado(Edatool):
                         f"move_files -fileset sim_1 [get_files {f['name']}]"
                     )
                     sim_files.append(
-                        f"set_property used_in_synthesis false [get_files {f['name']}]"
-                    )
-                    sim_files.append(
-                        f"set_property used_in_implementation false [get_files {f['name']}]"
+                        f"set_property used_in simulation [get_files {f['name']}]"
                     )
                     unused_files.append(f)
 

--- a/edalize/tools/vivado.py
+++ b/edalize/tools/vivado.py
@@ -145,14 +145,14 @@ class Vivado(Edatool):
             if cmd:
                 if not self._add_include_dir(f, incdirs, True):
                     src_files.append(cmd + " {" + f["name"] + "}")
-                if "simulation" in f.get("tags", []):
-                    sim_files.append(
-                        f"move_files -fileset sim_1 [get_files {f['name']}]"
-                    )
-                    sim_files.append(
-                        f"set_property used_in simulation [get_files {f['name']}]"
-                    )
-                    unused_files.append(f)
+                    if "simulation" in f.get("tags", []):
+                        sim_files.append(
+                            f"move_files -fileset sim_1 [get_files {f['name']}]"
+                        )
+                        sim_files.append(
+                            f"set_property used_in simulation [get_files {f['name']}]"
+                        )
+                        unused_files.append(f)
 
                 dep_files.append(f["name"])
             else:

--- a/tests/tools/vivado/tags/design.tcl
+++ b/tests/tools/vivado/tags/design.tcl
@@ -25,8 +25,7 @@ read_mem {bootrom.mem}
 read_verilog -sv {another_sv_file.sv}
 read_verilog {testbench.v}
 move_files -fileset sim_1 [get_files testbench.v]
-set_property used_in_synthesis false [get_files testbench.v]
-set_property used_in_implementation false [get_files testbench.v]
+set_property used_in simulation [get_files testbench.v]
 
 set_property include_dirs [list . .] [get_filesets sources_1]
 set_property top top_module [current_fileset]


### PR DESCRIPTION
Closes https://github.com/olofk/edalize/issues/474

Based on @rbrglez hard-work from this PR https://github.com/olofk/edalize/pull/475

I have updated Vivado tests. Original commit with @rbrglez as co-author is preserved.

Additionally, I have fixed another issue. When adding Verilog/SystemVerilog header file/include directory with the simulation tag, the property was set on non-existing path because header file/include directory was not added. I have moved the whole logic inside the `if not self._add_include_dir():` block. Now, it is also working for Verilog/SystemVerilog header files/include directories when the `simulation` tag was set.